### PR TITLE
chore/unit-tests-for-connect-module

### DIFF
--- a/services/liquid-auth-api-js/src/connect/connect.controller.spec.ts
+++ b/services/liquid-auth-api-js/src/connect/connect.controller.spec.ts
@@ -16,7 +16,7 @@ describe('ConnectController', () => {
       providers: [
         {
           provide: AuthService,
-          useValue:,mockAuthService,
+          useValue: mockAuthService,
         },
         {
           provide: 'ACCOUNT_LINK_SERVICE',

--- a/services/liquid-auth-api-js/src/connect/connect.controller.spec.ts
+++ b/services/liquid-auth-api-js/src/connect/connect.controller.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AlgodService } from '../algod/algod.service';
+import { ConnectController } from './connect.controller';
+import { AuthService } from '../auth/auth.service';
+import * as crypto from 'node:crypto';
+import { Session } from './session.schema';
+import { accFixture } from '../../tests/constants';
+
+describe('ConnectController', () => {
+  let connectController: ConnectController;
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      controllers: [ConnectController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            init: jest.fn().mockResolvedValue({
+              id: crypto.randomBytes(32).toString('base64url'),
+              wallet: accFixture.accs[0].addr,
+              credentials: [],
+            }),
+          },
+        },
+        {
+          provide: 'ACCOUNT_LINK_SERVICE',
+          useValue: {
+            emit: jest.fn(),
+          },
+        },
+        {
+          provide: AlgodService,
+          useValue: {
+            accountInformation: jest.fn().mockReturnThis(),
+            exclude: jest.fn().mockReturnThis(),
+            do: jest.fn().mockResolvedValue({
+              'auth-addr': accFixture.accs[1].addr,
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    connectController = moduleRef.get<ConnectController>(ConnectController);
+  });
+
+  it('should be defined', () => {
+    expect(connectController).toBeDefined();
+  });
+
+  describe('connect response', () => {
+    it('(CREATED) should return undefined when a valid account & signature requests to connect', async () => {
+      const session = new Session();
+
+      const linkResponseDTO = {
+        requestId: 0,
+        wallet: accFixture.accs[0].addr,
+        challenge: accFixture.challenge,
+        signature: accFixture.accs[0].signature,
+        credId: '',
+      };
+
+      const response = await connectController.linkWalletResponse(
+        session,
+        linkResponseDTO,
+      );
+
+      expect(response).toBe(undefined);
+    });
+
+    it("(FAIL)    should throw an error when the signature doesn't match the account", async () => {
+      const session = new Session();
+
+      const linkResponseDTO = {
+        requestId: 0,
+        wallet: accFixture.accs[0].addr,
+        challenge: accFixture.challenge,
+        signature: accFixture.accs[2].signature,
+        credId: '',
+      };
+
+      await expect(
+        connectController.linkWalletResponse(session, linkResponseDTO),
+      ).rejects.toThrowError();
+    });
+
+    it('(CREATED) should return undefined when a valid account & auth address signature requests to connect', async () => {
+      const session = new Session();
+
+      const linkResponseDTO = {
+        requestId: 0,
+        wallet: accFixture.accs[0].addr,
+        challenge: accFixture.challenge,
+        signature: accFixture.accs[1].signature,
+        credId: '',
+      };
+
+      const response = await connectController.linkWalletResponse(
+        session,
+        linkResponseDTO,
+      );
+
+      expect(response).toBe(undefined);
+    });
+  });
+});

--- a/services/liquid-auth-api-js/src/connect/connect.controller.spec.ts
+++ b/services/liquid-auth-api-js/src/connect/connect.controller.spec.ts
@@ -2,10 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AlgodService } from '../algod/algod.service';
 import { ConnectController } from './connect.controller';
 import { AuthService } from '../auth/auth.service';
-import * as crypto from 'node:crypto';
 import { Session } from './session.schema';
 import { accFixture } from '../../tests/constants';
 import { mockAuthService } from '../__mocks__/auth.service.mock';
+import { mockAccountLinkService } from '../__mocks__/account-link.service.mock';
 
 describe('ConnectController', () => {
   let connectController: ConnectController;
@@ -16,13 +16,11 @@ describe('ConnectController', () => {
       providers: [
         {
           provide: AuthService,
-          useValue: mockAuthService,
+          useValue: { ...mockAuthService },
         },
         {
           provide: 'ACCOUNT_LINK_SERVICE',
-          useValue: {
-            emit: jest.fn(),
-          },
+          useValue: { ...mockAccountLinkService },
         },
         {
           provide: AlgodService,

--- a/services/liquid-auth-api-js/src/connect/connect.controller.spec.ts
+++ b/services/liquid-auth-api-js/src/connect/connect.controller.spec.ts
@@ -5,6 +5,7 @@ import { AuthService } from '../auth/auth.service';
 import * as crypto from 'node:crypto';
 import { Session } from './session.schema';
 import { accFixture } from '../../tests/constants';
+import { mockAuthService } from '../__mocks__/auth.service.mock';
 
 describe('ConnectController', () => {
   let connectController: ConnectController;
@@ -15,13 +16,7 @@ describe('ConnectController', () => {
       providers: [
         {
           provide: AuthService,
-          useValue: {
-            init: jest.fn().mockResolvedValue({
-              id: crypto.randomBytes(32).toString('base64url'),
-              wallet: accFixture.accs[0].addr,
-              credentials: [],
-            }),
-          },
+          useValue:,mockAuthService,
         },
         {
           provide: 'ACCOUNT_LINK_SERVICE',
@@ -69,7 +64,7 @@ describe('ConnectController', () => {
       expect(response).toBe(undefined);
     });
 
-    it("(FAIL)    should throw an error when the signature doesn't match the account", async () => {
+    it("(FAIL) should throw an error when the signature doesn't match the account", async () => {
       const session = new Session();
 
       const linkResponseDTO = {


### PR DESCRIPTION
Description
- added unit tests for connect module controller
- removed express response object where possible to avoid mocking (commited accidently in [rekey support PR](https://github.com/algorandfoundation/liquid-auth/pull/2))
- Jira: [ENG-283](https://algorandfoundation.atlassian.net/browse/ENG-283)


[ENG-283]: https://algorandfoundation.atlassian.net/browse/ENG-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ