### PR TITLE
docs: corrects example ngrok.yml file's to match docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ version: 2
 authtoken: <NGROK_AUTH_TOKEN>
 tunnels:
   website:
-    addr: liquid-demo:5173
+    addr: liquid-auth:5173
     proto: http
     domain: <NGROK_STATIC_DOMAIN>
 


### PR DESCRIPTION
# ℹ Overview

The docker compose service is called liquid-auth. The ngrok.yml file needs to also point to liquid-auth:5173, not liquid-demo:5173. Otherwise a `no host found` error appears when navigating to your ngrok static domain.

### 📝 Related Issues

None

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Conventional Commits
- [x] `yarn test:cov` passes
