### PR TITLE
Documentation: Integrate Plausible analytics

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -28,6 +28,22 @@ export default defineConfig({
       logo: {
         src: './public/logo.svg',
       },
+      head: [
+        // GTM Script
+        {
+          tag: 'script',
+          attrs: {
+            'is:inline': true,
+          },
+          content: `
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','GTM-MK3HM7BF');
+          `,
+        },
+      ],
       editLink: {
         baseUrl:
           'https://github.com/algorandfoundation/liquid-auth/edit/develop/docs/',
@@ -50,6 +66,9 @@ export default defineConfig({
           },
         ]),
       ],
+      components: {
+        PageFrame: './src/components/PageFrame.astro',
+      },
       social: {
         github: 'https://github.com/algorandfoundation/liquid-auth',
       },

--- a/docs/src/components/GTMBody.astro
+++ b/docs/src/components/GTMBody.astro
@@ -1,0 +1,10 @@
+---
+const GTM_ID = 'GTM-MK3HM7BF';
+---
+
+<!-- Google Tag Manager (noscript) -->
+<noscript>
+  <iframe src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
+    height="0" width="0" style="display:none;visibility:hidden"></iframe>
+</noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/docs/src/components/PageFrame.astro
+++ b/docs/src/components/PageFrame.astro
@@ -4,7 +4,9 @@ import Default from '@astrojs/starlight/components/PageFrame.astro';
 import GTMBody from './GTMBody.astro';
 ---
 
+<GTMBody />
 <Default {...Astro.props}>
-  <GTMBody />
+  <slot name="header" slot="header" />
+  <slot name="sidebar" slot="sidebar" />
   <slot />
 </Default>

--- a/docs/src/components/PageFrame.astro
+++ b/docs/src/components/PageFrame.astro
@@ -1,0 +1,10 @@
+---
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/PageFrame.astro';
+import GTMBody from './GTMBody.astro';
+---
+
+<Default {...Astro.props}>
+  <GTMBody />
+  <slot />
+</Default>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -18,6 +18,17 @@ export const lang = "en"
   <meta name="description" content="Web3 meets real world Authentication"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" type="image/svg+xml" href={`${base}logo-background.svg`} />
+
+  <!-- Google Tag Manager -->
+  <script is:inline>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-MK3HM7BF');
+  </script>
+  <!-- End Google Tag Manager -->
+
   <style is:global>
       html, body {
           height: 100%;
@@ -32,6 +43,13 @@ export const lang = "en"
   </style>
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MK3HM7BF"
+            height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
   <div class="min-h-full">
     <Header />
     <HeroSection />


### PR DESCRIPTION
## Summary

This PR integrates Google Tag Manager (GTM) script into the Liquid-Auth documentation site to enable site analytics with Plausible. The integration follows GTM best practices by including both the primary script tag and the noscript fallback.

## Changes Made

### 1. GTM Script Integration (`docs/astro.config.mjs`)
- Added GTM initialization script to Starlight's `head` configuration
- Script loads GTM with ID `GTM-MK3HM7BF` for Plausible Analytics integration

### 2. GTM Noscript Fallback Component (`docs/src/components/GTMBody.astro`)
- Created new component to provide GTM fallback for users with JavaScript disabled
- Includes iframe pointing to GTM's noscript endpoint per [GTM documentation](https://developers.google.com/tag-manager/quickstart)

### 3. PageFrame Component Override (`docs/src/components/PageFrame.astro`)
- Overrode Starlight's `PageFrame` component to inject GTM noscript at the beginning of the body tag
- Properly passes through named slots (`header`, `sidebar`) to maintain site layout and navigation
- Wraps default PageFrame component to preserve all functionality

### 4. Landing Page Updates (`docs/src/pages/index.astro`)
- Added GTM integration to the custom landing page

## Technical Details

The GTM integration follows the standard two-part approach:
1. **Script tag** in `<head>` - Primary tracking method (loaded via `astro.config.mjs`)
2. **Noscript iframe** immediately after `<body>` opens - Fallback for non-JS browsers (injected via `PageFrame` override)

The `PageFrame` component override required careful handling of Starlight's named slots to ensure the header and sidebar navigation continue to render correctly.

## Testing

- ✅ Site renders correctly with navigation and header
- ✅ GTM script loads in browser
- ✅ Noscript fallback present in DOM
- ✅ No console errors or layout issues

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Conventional Commits
- [x] `yarn test:cov` passes
