### PR TITLE
fixed paths for `trailingSlash: 'never'`

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -17,6 +17,7 @@ export default defineConfig({
     },
   },
   site: 'https://liquidauth.com',
+  trailingSlash: 'never',
   markdown: {
     rehypePlugins: [rehypeMermaid],
   },

--- a/docs/src/components/header.astro
+++ b/docs/src/components/header.astro
@@ -7,7 +7,7 @@ const logo = `${base}/logo.svg`;
 const links = [
   {
     title: 'Deep Dive',
-    href: `${base}/architecture/`
+    href: `${base}/architecture`
   },
   {
     title: 'Features',

--- a/docs/src/content/docs/architecture.md
+++ b/docs/src/content/docs/architecture.md
@@ -7,7 +7,7 @@ next: false
 ---
 
 This is a high level overview of the sequence of events that happens while using Liquid Auth.
-See the [Getting Started](./guides/getting-started) section for more detailed information on each step.
+See the [Getting Started](../guides/getting-started) section for more detailed information on each step.
 Diagrams are generated using [Mermaid](https://mermaid-js.github.io/mermaid/#/).
 
 ## Authentication

--- a/docs/src/content/docs/clients/android/introduction.mdx
+++ b/docs/src/content/docs/clients/android/introduction.mdx
@@ -5,7 +5,7 @@ prev: false
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Aside type="caution">
-  Handling [Passkeys](../../guides/concepts#passkeys) in Android can be non-trivial and requires careful planning when integrating
+  Handling [Passkeys](../../../guides/concepts#passkeys) in Android can be non-trivial and requires careful planning when integrating
 </Aside>
 
 The Android Client is a library that allows you to interact with the Liquid Auth Service and provides
@@ -35,7 +35,7 @@ keytool -list -v -keystore <path> -alias <alias> -storepass <store_password> -ke
 
 Run a local instance
 or deploy the [Liquid Auth Service](../../../server/running-locally)
-using the SHA256 fingerprint and application name in the [environment configuration](../../server/environment-variables)
+using the SHA256 fingerprint and application name in the [environment configuration](../../../server/environment-variables)
 
 ### Install
 

--- a/docs/src/content/docs/clients/browser/authentication.md
+++ b/docs/src/content/docs/clients/browser/authentication.md
@@ -6,7 +6,7 @@ sidebar:
     variant: danger
 ---
 
-Authenticate an existing [Passkey](/guides/concepts/#passkeys) with the [Service](/guides/server/introduction).
+Authenticate an existing [Passkey](../../guides/concepts#passkeys) with the [Service](../../server/introduction).
 
 ### Who is this for?
 

--- a/docs/src/content/docs/clients/browser/introduction.mdx
+++ b/docs/src/content/docs/clients/browser/introduction.mdx
@@ -6,7 +6,7 @@ import {Aside} from "@astrojs/starlight/components";
 
 The `SignalClient` is an EventEmitter interface
 that can be used
-to communicate with the [Service](../../server/introduction).
+to communicate with the [Service](../../../server/introduction).
 It's designed to facilitate authentication and peer-to-peer communications.
 The interface is composed of methods that can be manually executed.
 
@@ -17,7 +17,7 @@ npm install algorandfoundation/liquid-auth-js --save
 
 ## Get Started
 
-<Aside>The service must be running as the origin server. See the [server integrations](../../server/integrations) documentation</Aside>
+<Aside>The service must be running as the origin server. See the [server integrations](../../../server/integrations) documentation</Aside>
 
 ### Use-Wallet [WIP]
 We recommend using [use-wallet](https://github.com/TxnLab/use-wallet) from [TxnLabs](https://www.txnlab.dev/).

--- a/docs/src/content/docs/clients/browser/offer.mdx
+++ b/docs/src/content/docs/clients/browser/offer.mdx
@@ -8,10 +8,10 @@ import {Aside} from "@astrojs/starlight/components";
 
 <Aside type="caution">
   Ensure both clients have a valid session before attempting to create peer connections.
-  See the [Authentication](/docs/clients/browser/authentication) and [Registration]() guides for more information.
+  See the [Authentication](./authentication) and [Registration](./registration) guides for more information.
 </Aside>
 
-[Peer-to-Peer](/guides/concepts/#peer-to-peer) connections can only be done using the `SignalClient`.
+[Peer-to-Peer](../../guides/concepts/#peer-to-peer) connections can only be done using the `SignalClient`.
 Wallets are responsible for creating offers to connect.
 
 ### Who is this for?

--- a/docs/src/content/docs/guides/Passkey/authentication.mdx
+++ b/docs/src/content/docs/guides/Passkey/authentication.mdx
@@ -12,11 +12,11 @@ tags:
 ---
 import { Steps, LinkCard, CardGrid, Aside } from "@astrojs/starlight/components";
 
-Authenticating with a previously created [Passkey](../../concepts#passkeys) is a three-step process.
+Authenticating with a previously created [Passkey](../concepts#passkeys) is a three-step process.
 
 <Steps>
   1. Fetch the **Request Options** from the [Server](../../../server/introduction).
-  2. Retrieve the [Passkey](../../concepts#passkeys) using the **Request Options**.
+  2. Retrieve the [Passkey](../concepts#passkeys) using the **Request Options**.
   3. Post the **Assertion Response** from an authenticator to the [Server](../../../server/introduction).
 </Steps>
 

--- a/docs/src/content/docs/guides/Passkey/registration.mdx
+++ b/docs/src/content/docs/guides/Passkey/registration.mdx
@@ -13,11 +13,11 @@ tags:
 ---
 import { Steps, Aside, CardGrid, LinkCard} from '@astrojs/starlight/components';
 
-Registering a [Passkey](../../concepts#passkeys) is a three-step process.
+Registering a [Passkey](../concepts#passkeys) is a three-step process.
 
 <Steps>
   1. Fetch the **Creation Options** from the [Server](../../../server/introduction).
-  2. Create a new [Passkey](../../concepts#passkeys) using the **Creation Options**.
+  2. Create a new [Passkey](../concepts#passkeys) using the **Creation Options**.
   3. Post the **Attestation Response** from an authenticator to the [Server](../../../server/introduction).
 </Steps>
 

--- a/docs/src/content/docs/guides/Peer to Peer/offer.mdx
+++ b/docs/src/content/docs/guides/Peer to Peer/offer.mdx
@@ -6,7 +6,7 @@ sidebar:
 ---
 import {Aside, CardGrid, LinkCard} from '@astrojs/starlight/components';
 
-<Aside>The client must authenticate the request prior to sending the offer. See [Authentication](/guides/passkey/authentication/) for more information</Aside>
+<Aside>The client must authenticate the request prior to sending the offer. See [Authentication](/guides/passkey/authentication) for more information</Aside>
 
 An **Offer** is a type of session that is initiated by a client
 and is used to create a P2P connection with an **Answer** client.

--- a/docs/src/content/docs/guides/components.mdx
+++ b/docs/src/content/docs/guides/components.mdx
@@ -11,9 +11,9 @@ import { Aside } from '@astrojs/starlight/components';
 <Aside>You can find more information in the <a href="../../server/introduction">Server</a> guide</Aside>
 
 The responsibilities of the service are limited to authentication and brokering connections between peers.
-Authentication is handled using [Passkeys](../concepts#-passkeys) with a custom `Liquid Extension`
+Authentication is handled using [Passkeys](./concepts#-passkeys) with a custom `Liquid Extension`
 which attests an additional KeyPair (ie Algorand Account).
-Once a client is authenticated, the service can be used to broker a [Peer to Peer](../concepts#-peer-to-peer) connection.
+Once a client is authenticated, the service can be used to broker a [Peer to Peer](./concepts#-peer-to-peer) connection.
 
 
 #### Who should use this service?

--- a/docs/src/content/docs/server/running-locally.md
+++ b/docs/src/content/docs/server/running-locally.md
@@ -19,7 +19,7 @@ echo $CR_PAT | docker login ghcr.io -u <USERNAME> --password-stdin
 ## Docker Image
 
 The service is designed to be run in a Docker container, it requires a [MongoDB]() and [Redis]() instance to be running.
-See the [Environment Variables](../environment-variables) section for more information about crafting a `.env.docker` file.
+See the [Environment Variables](./environment-variables) section for more information about crafting a `.env.docker` file.
 
 ```bash 
 docker run -d --env-file .env.docker -p 3000:3000 ghcr.io/algorandfoundation/liquid-auth:develop
@@ -85,4 +85,4 @@ ngrok http --domain=<NGROK_STATIC_DOMAIN> 3000
 ```
 
 
-Ensure the service's `ORIGIN` and `HOSTNAME` [environment variables](../environment-variables) are configured correctly with the ngrok domain.
+Ensure the service's `ORIGIN` and `HOSTNAME` [environment variables](./environment-variables) are configured correctly with the ngrok domain.


### PR DESCRIPTION
There were a couple of inconsistencies with trailing-slash URLs in the `docs/`.
In this PR I decided to go with `never` using trailing slashes, because that is more consistent with the majority of urls.
The PR also fixes all paths that broke after the change, streamlining them in that regard.
It does not address the mix of relative and absolutes paths.