### PR TITLE
fix: Uint8Array type error on assertion service breaking tests

### DIFF
--- a/src/assertion/assertion.service.ts
+++ b/src/assertion/assertion.service.ts
@@ -71,7 +71,7 @@ export class AssertionService {
       expectedOrigin,
       expectedRPID,
       credential: {
-        publicKey: fromBase64Url(userCredential.publicKey),
+        publicKey: new Uint8Array(fromBase64Url(userCredential.publicKey)),
         counter: userCredential.prevCounter,
         id: userCredential.credId,
       },


### PR DESCRIPTION
# What

Fixing Uint8Array type expected when parsing into creds publickey. 
