### PR TITLE
feat(pairing): add durable reconnect authorization

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -2,6 +2,17 @@
 NODE_ENV=production
 SENTRY_DNS=
 PORT=3000
+# Generate these independently with `openssl rand -base64 48`.
+SESSION_SECRET=replace-with-a-random-session-secret
+SESSION_SECURE=true
+SESSION_TTL_SECONDS=20000
+SESSION_COOKIE_MAX_AGE_MS=20000000
+SESSION_SAME_SITE=lax
+TRUST_PROXY=true
+CORS_ORIGINS=https://catfish-pro-wolf.ngrok-free.app
+# Back up this value and do not rotate it after pairings have been created.
+PAIRING_CREDENTIAL_SECRET=replace-with-an-independent-secret
+PAIRING_INVITATION_TTL_SECONDS=900
 
 # Database
 DB_HOST=mongo:27017

--- a/.env.template
+++ b/.env.template
@@ -1,6 +1,17 @@
 # Application
 NODE_ENV=development
 SENTRY_DNS=
+# Generate these independently with `openssl rand -base64 48`.
+SESSION_SECRET=replace-with-a-random-session-secret
+SESSION_SECURE=false
+SESSION_TTL_SECONDS=20000
+SESSION_COOKIE_MAX_AGE_MS=20000000
+SESSION_SAME_SITE=lax
+TRUST_PROXY=false
+CORS_ORIGINS=http://localhost
+# Back up this value and do not rotate it after pairings have been created.
+PAIRING_CREDENTIAL_SECRET=replace-with-an-independent-secret
+PAIRING_INVITATION_TTL_SECONDS=900
 
 # Database
 DB_HOST=localhost:27017

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ This guide is designed to get the project running locally in a dockerized contai
 See the full [Service Documentation](https://liquidauth.com/server/introduction/) for more information
 
 ### Prerequisites
-- Node.js 18+
+
+- Node.js 20+
 - Docker
 
 #### Clone the project
@@ -39,6 +40,7 @@ Don't run the ngrok commands directly as expressed in the ngrok guide as it will
 Add a `ngrok.yml` configuration to the root directory.
 
 ##### Example Configuration
+
 ```yaml
 version: 2
 authtoken: <NGROK_AUTH_TOKEN>
@@ -47,22 +49,32 @@ tunnels:
     addr: liquid-auth:3000
     proto: http
     domain: <NGROK_STATIC_DOMAIN>
-
 ```
-*Make sure to update the `authtoken` and `domain` in the `ngrok.yml` file with your ngrok details.*
+
+_Make sure to update the `authtoken` and `domain` in the `ngrok.yml` file with your ngrok details._
 
 ### Service Configuration
 
-Update the [.env.docker](.env.docker) file with the following keys with the values from ngrok:
+Update the [.env.docker](.env.docker) file with the following keys. Generate
+`SESSION_SECRET` and `PAIRING_CREDENTIAL_SECRET` independently by running
+`openssl rand -base64 48` twice; production startup rejects the checked-in
+placeholders.
 
 ```bash
 HOSTNAME=<NGROK_STATIC_DOMAIN>
 ORIGIN=https://<NGROK_STATIC_DOMAIN>
+SESSION_SECRET=<FIRST_RANDOM_VALUE>
+PAIRING_CREDENTIAL_SECRET=<SECOND_RANDOM_VALUE>
 ```
+
+Keep `PAIRING_CREDENTIAL_SECRET` stable when reusing or restoring MongoDB. Losing
+or changing it makes existing durable pairing credentials unverifiable. See the
+[server configuration guide](https://liquidauth.com/server/environment-variables/)
+for backup and deployment requirements.
 
 ### User Interface
 
-A quick way to test the service is using the documentation site included in this repository. 
+A quick way to test the service is using the documentation site included in this repository.
 
 Navigate to the `docs` directory:
 

--- a/docs/src/content/docs/server/durable-pairings.md
+++ b/docs/src/content/docs/server/durable-pairings.md
@@ -1,0 +1,117 @@
+---
+title: 'Server: Durable pairings'
+sidebar:
+  order: 3
+  label: 'Durable pairings'
+---
+
+Liquid Auth v2 pairings authorize repeated signaling sessions without keeping
+an Express session alive or repeating WebAuthn. The provider and controller
+receive different, role-bound bearer credentials. Store them in each platform's
+secret store; never put them in a deep link, log, analytics event, or ordinary
+browser storage.
+
+## Create an invitation
+
+The provider creates an invitation before displaying its public pairing ID:
+
+```http
+POST /pairings/invitations
+Content-Type: application/json
+
+{"requestId":"optional-public-id-at-least-16-characters"}
+```
+
+If `requestId` is omitted, the server generates an ID. The response contains a
+provider credential that must be persisted before the deep link is shown:
+
+```json
+{
+  "version": 2,
+  "pairingId": "public-pairing-id",
+  "role": "provider",
+  "credential": "provider-bearer-secret",
+  "expiresAt": "2026-07-14T12:30:00.000Z"
+}
+```
+
+Only `pairingId` is public. The invitation expiry limits the initial WebAuthn
+approval window; it does not expire an approved pairing.
+
+## Approve from a controller
+
+Pass the public `pairingId` as `requestId` when requesting assertion or
+attestation options. The verified response must carry the same Liquid extension
+request ID. On success, the normal user response includes the controller's
+role-bound credential:
+
+```json
+{
+  "pairing": {
+    "version": 2,
+    "pairingId": "public-pairing-id",
+    "role": "controller",
+    "credential": "controller-bearer-secret"
+  }
+}
+```
+
+A repeated, valid WebAuthn approval for the same wallet recovers from a lost
+HTTP response by issuing a fresh controller credential. Replace the previously
+stored controller credential with the returned value. The provider credential
+does not rotate.
+
+## Reconnect signaling
+
+Both roles send their full credential object as Socket.IO handshake `auth`:
+
+```json
+{
+  "version": 2,
+  "pairingId": "public-pairing-id",
+  "role": "controller",
+  "credential": "controller-bearer-secret"
+}
+```
+
+After approval, this remains valid across process restarts, session-cookie
+expiry, Socket.IO disconnects, and new WebRTC negotiations. A physical WebRTC
+connection is disposable; reconnect it with the stored credential rather than
+repeating WebAuthn.
+
+## Read status
+
+Either role can authenticate its own status request:
+
+```http
+GET /pairings/public-pairing-id/status
+Authorization: Bearer <role-credential>
+X-Pairing-Role: provider
+```
+
+The status is `pending`, `active`, or `revoked`. A role header never authorizes
+the other role's credential.
+
+## Revoke
+
+Explicit removal calls:
+
+```http
+DELETE /pairings/public-pairing-id
+Authorization: Bearer <role-credential>
+X-Pairing-Role: controller
+```
+
+Either role can revoke the whole pairing. DELETE is idempotent with the same
+credential, including when the first response was lost. Active records and
+pending invitations retain permanent revocation tombstones, so the ID cannot be
+reused or rebound.
+
+Treat `PAIRING_REVOKED` as terminal and remove the local pairing. Treat
+`PAIRING_UNAUTHORIZED` as an invalid/stale supplied credential; a controller may
+perform the single approved WebAuthn recovery flow. Database, Redis, proxy,
+Socket.IO transport, timeout, and generic server errors are transient and must
+not delete durable pairing state.
+
+See [Server configuration](./environment-variables/) for the stable secret,
+backup, tombstone, and rollout requirements.

--- a/docs/src/content/docs/server/environment-variables.md
+++ b/docs/src/content/docs/server/environment-variables.md
@@ -1,19 +1,65 @@
 ---
-title: "Server: Configuration"
+title: 'Server: Configuration'
 sidebar:
   order: 2
   label: 'Configuration'
 ---
 
-All configurations are set using environment variables.
-Creating a `.env.docker` file is recommended to store all the environment variables required to run the server.
+Liquid Auth is configured with environment variables. When using Docker, keep
+the deployment-specific values in a protected `.env.docker` file or inject them
+from a secret manager. Do not commit real secrets to source control.
 
-The following sections describe the environment variables required to run the server.
+## Production secrets
 
-## Environment Variables
+Production startup requires two explicit, independent secrets. Generate each
+value separately; for example, run `openssl rand -base64 48` twice and store the
+two results in your secret manager.
 
-Attestations and Assertions require a valid `RP_NAME`, `HOSTNAME`, and `ORIGIN` to be set.
-`ORIGIN` and `HOSTNAME` must be set to a valid domain secured with HTTPS.
+| Variable                    | Required in production | Purpose                                                                                   |
+| --------------------------- | ---------------------- | ----------------------------------------------------------------------------------------- |
+| `SESSION_SECRET`            | Yes                    | Signs the Express session cookie.                                                         |
+| `PAIRING_CREDENTIAL_SECRET` | Yes                    | Keys the hashes used to authenticate durable provider and controller pairing credentials. |
+
+Each secret must contain at least 32 characters with sufficient character
+variety, must not be a placeholder, and the two values must not be equal. The
+server refuses to start with an unsafe production configuration. Development
+and test environments retain local defaults for convenience.
+
+`PAIRING_CREDENTIAL_SECRET` is durable application data, not a disposable
+deployment secret. Every server replica must use exactly the same value. Back it
+up alongside the MongoDB data and restore both together. **Do not rotate, delete,
+or regenerate this secret after creating pairings.** Existing credential hashes
+cannot be checked with a different key, so changing it invalidates every stored
+pairing and forces users to pair again. Rotation requires a separately designed
+credential migration or key-ring rollout; a routine deploy must keep this value
+stable.
+
+Changing `SESSION_SECRET` invalidates current browser sessions. Keep it stable
+across replicas and routine deploys as well, but always keep it independent from
+`PAIRING_CREDENTIAL_SECRET` so a session-key change cannot silently invalidate
+durable pairings.
+
+## Application, sessions, and pairing
+
+| Variable                         | Default                            | Description                                                                                                                  |
+| -------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `NODE_ENV`                       | `development`                      | Set to `production` in a deployment; this enables strict secret validation.                                                  |
+| `PORT`                           | `3000`                             | HTTP and Socket.IO listening port.                                                                                           |
+| `SENTRY_DNS`                     | unset                              | Sentry DSN when error reporting is enabled.                                                                                  |
+| `SESSION_SECRET`                 | Local-only default                 | Required production session signing secret described above.                                                                  |
+| `SESSION_SECURE`                 | `false`                            | Set to `true` when cookies are served over HTTPS.                                                                            |
+| `SESSION_TTL_SECONDS`            | `20000`                            | Session record lifetime in MongoDB, in seconds. This does not expire an approved pairing.                                    |
+| `SESSION_COOKIE_MAX_AGE_MS`      | `20000000`                         | Session cookie lifetime in milliseconds. This does not expire an approved pairing.                                           |
+| `SESSION_SAME_SITE`              | `lax`                              | Express session cookie `SameSite` value.                                                                                     |
+| `TRUST_PROXY`                    | `false`                            | Set to `true` when a trusted reverse proxy terminates HTTPS.                                                                 |
+| `CORS_ORIGINS`                   | `ORIGIN`, then `http://localhost`  | Comma-separated browser origins allowed to send credentialed requests.                                                       |
+| `PAIRING_CREDENTIAL_SECRET`      | Local-only session-secret fallback | Required independent production key described above.                                                                         |
+| `PAIRING_INVITATION_TTL_SECONDS` | `900`                              | Time in seconds that an unapproved pairing invitation can be claimed. It does not limit the lifetime of an approved pairing. |
+
+## WebAuthn and application links
+
+Attestations and assertions require a valid `RP_NAME`, `HOSTNAME`, and `ORIGIN`.
+`ORIGIN` and `HOSTNAME` must use a domain secured with HTTPS.
 
 ```sh
 RP_NAME=<SERVICE_NAME> # Friendly name of the service
@@ -21,14 +67,15 @@ HOSTNAME=<DOMAIN_NAME> # Hostname of the service
 ORIGIN=https://<DOMAIN_NAME> # Origin of the service
 ```
 
-If you are using a custom Android client, make sure to update the `SHA256` fingerprint.
+If you are using a custom Android client, update its package name and signing
+certificate fingerprint.
 
 ```bash
 ANDROID_SHA256HASH=<00:00:...> # SHA256 fingerprint of the Android client
 ANDROID_PACKAGENAME=<com.example.my-wallet> # Package name of the Android client
 ```
 
-Configuration for MongoDB
+## MongoDB
 
 ```bash
 DB_HOST=<MONGO_DB_HOST:PORT> # Hostname of the MongoDB instance
@@ -38,7 +85,10 @@ DB_NAME=<MONGO_DB_NAME> # Database name
 DB_ATLAS=false # Set to true if using MongoDB Atlas
 ```
 
-Configuration for Redis
+MongoDB stores sessions, active pairings, and revocation tombstones. Use durable
+storage and include it in backups.
+
+## Redis
 
 ```bash
 REDIS_HOST=<REDIS_HOST> # Hostname of the Redis instance
@@ -47,10 +97,67 @@ REDIS_USERNAME=<REDIS_USERNAME> # Username for the Redis instance
 REDIS_PASSWORD= # Password for the Redis instance
 ```
 
-## Full Example 
+Redis distributes signaling and revocation events between replicas. Pairing
+authorization remains durable in MongoDB and does not depend on Redis retaining
+historical messages.
+
+## Durable reconnect and revocation
+
+An approved pairing is not tied to the browser session or invitation TTL. A
+provider or controller can return after either has expired and authenticate with
+its saved pairing ID, role, and credential. Temporary HTTP, Socket.IO, Redis, or
+database failures are retryable and do not remove a pairing.
+
+Revocation is credential-authenticated and idempotent. Revoked active pairings
+remain in MongoDB with `status: revoked`. Revoking an unapproved invitation
+removes its TTL field and retains the invitation as a permanent tombstone. These
+tombstones prevent a public pairing ID from being recreated or rebound after an
+explicit removal. Back up tombstones with the rest of MongoDB and do not apply a
+cleanup TTL to revoked records. Restoring a database snapshot from before a
+revocation also restores the older pairing state, so retain and restore the
+latest revocation records when recovering a deployment.
+
+Signaling clients receive `PAIRING_REVOKED` only for an explicit revocation and
+should treat it as terminal. `PAIRING_UNAUTHORIZED` means the supplied durable
+credential is invalid; clients must stop retrying that credential and may start
+an approved credential-recovery flow. Operational and transport errors have no
+terminal pairing code and should be retried without deleting local pairing
+state.
+
+## Rollout order
+
+Roll out the durable protocol in dependency order so frozen consumer lockfiles
+cannot install an older implementation:
+
+1. Deploy the Liquid Auth server and its stable production secrets. The server
+   remains compatible with legacy session clients while adding v2 pairings.
+2. Publish the updated `@algorandfoundation/liquid-client` and
+   `@algorandfoundation/ac2-sdk` packages.
+3. Refresh the OpenClaw plugin and controller-app lockfiles against those exact
+   published artifacts, run their integration tests, and only then publish or
+   deploy the consumers.
+
+Do not release a consumer whose lockfile still resolves an earlier client or
+SDK canary merely because its manifest range accepts the new version; frozen
+package-manager installs use the recorded resolution.
+
+## Full example
 
 ```bash
 # .env.docker
+
+# Application
+NODE_ENV=production
+PORT=3000
+SESSION_SECRET=<FIRST_INDEPENDENT_RANDOM_VALUE>
+SESSION_SECURE=true
+SESSION_TTL_SECONDS=20000
+SESSION_COOKIE_MAX_AGE_MS=20000000
+SESSION_SAME_SITE=lax
+TRUST_PROXY=true
+CORS_ORIGINS=https://my-static-domain.example
+PAIRING_CREDENTIAL_SECRET=<SECOND_INDEPENDENT_RANDOM_VALUE>
+PAIRING_INVITATION_TTL_SECONDS=900
 
 # Database
 DB_HOST=mongo:27017
@@ -67,8 +174,8 @@ REDIS_PASSWORD=
 
 # FIDO2
 RP_NAME="Auth Server"
-HOSTNAME=my-static-domain.ngrok-free.app
-ORIGIN=https://my-static-domain.ngrok-free.app
+HOSTNAME=my-static-domain.example
+ORIGIN=https://my-static-domain.example
 
 ANDROID_SHA256HASH=47:CC:4E:EE:B9:50:59:A5:8B:E0:19:45:CA:0A:6D:59:16:F9:A9:C2:96:75:F8:F3:64:86:92:46:2B:7D:5D:5C
 ANDROID_PACKAGENAME=foundation.algorand.demo

--- a/docs/src/content/docs/server/integrations.md
+++ b/docs/src/content/docs/server/integrations.md
@@ -1,7 +1,7 @@
 ---
-title: "Server: Integrations"
+title: 'Server: Integrations'
 sidebar:
-  order: 3
+  order: 4
   label: 'Integrations'
 next: false
 ---
@@ -19,7 +19,7 @@ server {
     listen            80;
     listen       [::]:80;
     server_name  localhost;
-    
+
     root   /usr/share/nginx/html;
 
     location / {
@@ -39,6 +39,7 @@ server {
 ```
 
 ### Vite
+
 > We recommend running a proxy server like Nginx in production. This will work for local development
 
 ```typescript
@@ -57,12 +58,13 @@ export default defineConfig({
         target: process.env.WSS_PROXY_SERVER || DEFAULT_WSS_PROXY_URL,
         ws: true,
       },
-    }
+    },
   },
-})
+});
 ```
 
 ### Next.js
+
 > We recommend running a proxy server like Nginx in production. This will work in a pinch or to test locally.
 
 Deploy the service to a platform like Render or AWS then configure the Proxy in `next.config.js`.
@@ -71,7 +73,7 @@ Deploy the service to a platform like Render or AWS then configure the Proxy in 
 //next.config.js
 /** @type {import('next').NextConfig} */
 
-const serverURL = "https://my-liquid-service.com";
+const serverURL = 'https://my-liquid-service.com';
 
 const nextConfig = {
   trailingSlash: true,
@@ -102,7 +104,7 @@ const nextConfig = {
         source: '/socket.io',
         destination: `${serverURL}/socket.io/`,
       },
-    ]
+    ];
   },
 };
 
@@ -110,8 +112,15 @@ export default nextConfig;
 ```
 
 ### Nest.js
+
 > Warning, the Service package is still a work in progress.
 > Please contact if you are interested in mounting the server
+
+The mounted `AppModule` uses the same production configuration checks as the
+standalone server. Provide independent `SESSION_SECRET` and
+`PAIRING_CREDENTIAL_SECRET` environment variables, and keep the pairing secret
+stable across replicas, restarts, and database restores. See the
+[configuration guide](./environment-variables/) before creating pairings.
 
 ```shell
 npm install algorandfoundation/liquid-auth --save
@@ -126,10 +135,10 @@ async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     logger: ['error', 'warn', 'debug', 'log', 'verbose'],
   });
-  
+
   // Get Configuration
   const config = app.get<ConfigService>(ConfigService);
- 
+
   // Enable Swagger Docs
   const swaggerConfig = new DocumentBuilder()
     .setTitle('Liquid Dapp')
@@ -139,14 +148,14 @@ async function bootstrap() {
     .build();
   const document = SwaggerModule.createDocument(app, swaggerConfig);
   SwaggerModule.setup('docs', app, document);
- 
+
   // Setup Session Storeage
   const username = config.get('database.username');
   const host = config.get('database.host');
   const password = config.get('database.password');
   const name = config.get('database.name');
   const isAtlas = config.get('database.atlas');
- 
+
   const uri = `mongodb${
     isAtlas ? '+srv' : ''
   }://${username}:${password}@${host}/${name}?authSource=admin&retryWrites=true&w=majority`;
@@ -157,7 +166,7 @@ async function bootstrap() {
   });
 
   const sessionHandler = session({
-    secret: "REPLACE_WITH_SESSION_SECRET",
+    secret: 'REPLACE_WITH_SESSION_SECRET',
     saveUninitialized: true,
     resave: true,
     cookie: {
@@ -167,7 +176,7 @@ async function bootstrap() {
     store,
   });
   app.use(sessionHandler);
-  
+
   // Configure Redis Adapter
   const redisIoAdapter = new RedisIoAdapter(app, sessionHandler);
   await redisIoAdapter.connectToRedis(config);
@@ -180,6 +189,7 @@ async function bootstrap() {
 ```
 
 ### Vercel
+
 > We recommend running a proxy server like Nginx in production. This will work in a pinch
 
 ```json
@@ -214,4 +224,3 @@ async function bootstrap() {
   ]
 }
 ```
-

--- a/docs/src/content/docs/server/introduction.md
+++ b/docs/src/content/docs/server/introduction.md
@@ -18,5 +18,21 @@ backed by a [Redis Adapter](https://socket.io/docs/v4/redis-adapter/).
 The service request to be running on the same origin as the dApp.
 We recommend configuring your frontend service to proxy requests to the authentication service.
 
+#### Durable pairing lifecycle
 
+Liquid Auth v2 pairings are durable credentials stored in MongoDB. Once an
+invitation is approved, the provider and controller can reconnect after session
+expiry, process restarts, network outages, or an arbitrarily long absence. The
+invitation TTL limits only the initial approval window; it is not a pairing
+lease.
 
+The server preserves explicit revocations as tombstones. A revoked active
+pairing cannot authenticate again, and a revoked pending invitation cannot be
+recreated with the same public ID. `PAIRING_REVOKED` is the terminal signal for
+clients to remove a pairing. `PAIRING_UNAUTHORIZED` stops retries with an invalid
+credential and may trigger credential recovery. Signaling and infrastructure
+failures are retryable and must not remove local pairing state.
+
+This durability depends on retaining MongoDB and keeping
+`PAIRING_CREDENTIAL_SECRET` unchanged. See [Server Configuration](./environment-variables/)
+for the deployment, backup, and secret requirements.

--- a/docs/src/content/docs/server/running-locally.md
+++ b/docs/src/content/docs/server/running-locally.md
@@ -2,15 +2,22 @@
 title: 'Server: Running Locally'
 sidebar:
   order: 1
-  label: "Running Locally" 
+  label: 'Running Locally'
 ---
 
 The Liquid Auth service is distributed as a Docker image. FIDO2 and WebRTC require a secure connection, we recommend [using ngrok](#ngrok) to create a secure tunnel to your local server.
 See the server [integrations](./integrations) guide for examples of how to add Liquid Auth to a web application.
 
+The checked-in `.env.docker` contains intentionally invalid placeholders. Before
+starting with `NODE_ENV=production`, generate independent values for
+`SESSION_SECRET` and `PAIRING_CREDENTIAL_SECRET`. Keep the pairing secret stable
+if you reuse the MongoDB volume; changing it makes credentials stored in that
+volume unverifiable.
+
 ### Prerequisites
 
 [Install Docker]() and [login to the GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic).
+
 ```bash
 export CR_PAT=<YOUR_TOKEN>
 echo $CR_PAT | docker login ghcr.io -u <USERNAME> --password-stdin
@@ -21,11 +28,12 @@ echo $CR_PAT | docker login ghcr.io -u <USERNAME> --password-stdin
 The service is designed to be run in a Docker container, it requires a [MongoDB]() and [Redis]() instance to be running.
 See the [Environment Variables](./environment-variables) section for more information about crafting a `.env.docker` file.
 
-```bash 
+```bash
 docker run -d --env-file .env.docker -p 3000:3000 ghcr.io/algorandfoundation/liquid-auth:develop
 ```
 
 ### Compose Example
+
 > Example of using Docker Compose to run the Liquid Auth service.
 
 ```yaml
@@ -36,14 +44,14 @@ services:
     env_file:
       - .env.docker
     ports:
-      - "3000:3000"
+      - '3000:3000'
     depends_on:
       - redis
       - mongo
   redis:
     image: redis
     ports:
-      - "6379:6379"
+      - '6379:6379'
   mongo:
     image: mongo:7.0
     environment:
@@ -51,7 +59,7 @@ services:
       - MONGO_INITDB_ROOT_USERNAME=${DB_USERNAME:-algorand}
       - MONGO_INITDB_ROOT_PASSWORD=${DB_PASSWORD:-algorand}
     ports:
-      - "27017:27017"
+      - '27017:27017'
     volumes:
       - mongo:/data/db
 volumes:
@@ -72,17 +80,17 @@ docker build -t my-amazing-liquid-auth:latest .
 Sign up for a free account at [ngrok](https://ngrok.com/) and follow the instructions to get your `<NGROK_AUTH_TOKEN>` and `<NGROK_STATIC_DOMAIN>`.
 
 #### Configuration
+
 ngrok will ask you to add your auth token to your configuration file.
 
-``` bash
+```bash
 ngrok config add-authtoken <NGROK_AUTH_TOKEN>
 ```
 
 It will then ask you to deploy your static domain, make sure to change the port to **3000** like this:
 
-``` bash
+```bash
 ngrok http --domain=<NGROK_STATIC_DOMAIN> 3000
 ```
-
 
 Ensure the service's `ORIGIN` and `HOSTNAME` [environment variables](./environment-variables) are configured correctly with the ngrok domain.

--- a/src/__fixtures__/configuration.fixture.json
+++ b/src/__fixtures__/configuration.fixture.json
@@ -6,7 +6,18 @@
   "origin": "http://catfish-pro-wolf.ngrok-free.app",
   "session": {
     "secure": false,
-    "secret": "secret"
+    "secret": "secret",
+    "ttlSeconds": 20000,
+    "cookieMaxAgeMs": 20000000,
+    "sameSite": "lax",
+    "trustProxy": false
+  },
+  "cors": {
+    "origins": ["http://localhost"]
+  },
+  "pairing": {
+    "credentialSecret": "secret",
+    "invitationTtlSeconds": 900
   },
   "socket": {
     "host": "localhost",

--- a/src/__mocks__/pairing.service.mock.ts
+++ b/src/__mocks__/pairing.service.mock.ts
@@ -1,0 +1,20 @@
+export const mockPairingService = {
+  createInvitation: jest.fn(),
+  bindInvitation: jest.fn(async (requestId: string) => ({
+    pairingId: requestId,
+  })),
+  approveInvitation: jest.fn(async (pairingId: string) => ({
+    version: 2,
+    pairingId,
+    role: 'controller' as const,
+    credential: 'controller-credential',
+  })),
+  findActivePairing: jest.fn(),
+  authenticateCredential: jest.fn(async (pairingId: string, role: string) => ({
+    version: 2,
+    pairingId,
+    role,
+    status: 'active' as const,
+  })),
+  revoke: jest.fn(),
+};

--- a/src/adapters/redis-io.adapter.ts
+++ b/src/adapters/redis-io.adapter.ts
@@ -13,6 +13,7 @@ export class RedisIoAdapter extends IoAdapter {
   private readonly sessionHandler: RequestHandler;
   private adapterConstructor: ReturnType<typeof createAdapter>;
   private pubClient: Redis;
+  private config: ConfigService;
   public subClient: Redis;
 
   constructor(app: NestExpressApplication, sessionHandler: RequestHandler) {
@@ -20,6 +21,7 @@ export class RedisIoAdapter extends IoAdapter {
     this.sessionHandler = sessionHandler;
   }
   async connectToRedis(config: ConfigService): Promise<void> {
+    this.config = config;
     this.pubClient = new Redis({
       host: config.get('socket.host'),
       port: config.get('socket.port'),
@@ -33,7 +35,15 @@ export class RedisIoAdapter extends IoAdapter {
   }
 
   createIOServer(port: number, options?: ServerOptions): any {
-    const server = super.createIOServer(port, options);
+    const origins = this.config?.get<string[]>('cors.origins') || [];
+    const server = super.createIOServer(port, {
+      ...options,
+      cors: {
+        ...(options?.cors || {}),
+        origin: origins,
+        credentials: true,
+      },
+    });
     server.engine.use(this.sessionHandler);
     server.adapter(this.adapterConstructor);
     return server;

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { AppController } from './app.controller.js';
 
 // Signals
 import { SignalsModule } from './signals/signals.module.js';
+import { PairingModule } from './pairings/pairing.module.js';
 
 export function mongooseModuleFactory(configService: ConfigService) {
   const database = configService.get('database');
@@ -40,6 +41,7 @@ export function mongooseModuleFactory(configService: ConfigService) {
     AuthModule,
     AttestationModule,
     AssertionModule,
+    PairingModule,
     SignalsModule,
   ],
   controllers: [AppController, AndroidController, IosController],

--- a/src/assertion/assertion.controller.spec.ts
+++ b/src/assertion/assertion.controller.spec.ts
@@ -18,7 +18,7 @@ import assertionRequestResponseFixtures from './__fixtures__/assertion.request.r
 import assertionResponseBodyFixtures from './__fixtures__/assertion.response.body.fixtures.json';
 import assertionResponseResponseFixtures from './__fixtures__/assertion.response.response.fixtures.json';
 
-import { UnauthorizedException } from '@nestjs/common';
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import {
   AssertionCredentialJSON,
   LiquidAssertionCredentialJSON,
@@ -26,6 +26,8 @@ import {
 } from './assertion.dto.js';
 import configurationFixture from '../__fixtures__/configuration.fixture.json';
 import androidUserAgentFixtures from '../__fixtures__/user-agent.android.fixtures.json';
+import { PairingService } from '../pairings/pairing.service.js';
+import { mockPairingService } from '../__mocks__/pairing.service.mock.js';
 
 // AssertionCredentialJSON
 const dummyAssertionCredentialJSON = {
@@ -45,6 +47,10 @@ describe('AssertionController', () => {
   let userModel: Model<User>;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+    mockPairingService.bindInvitation.mockRejectedValue(
+      new NotFoundException('Pairing invitation not found or expired'),
+    );
     userModel = mongoose.model('User', UserSchema);
 
     const moduleRef: TestingModule = await Test.createTestingModule({
@@ -66,6 +72,10 @@ describe('AssertionController', () => {
         {
           provide: 'ACCOUNT_LINK_SERVICE',
           useValue: { ...mockAccountLinkService },
+        },
+        {
+          provide: PairingService,
+          useValue: mockPairingService,
         },
         {
           provide: getModelToken(User.name),
@@ -122,6 +132,57 @@ describe('AssertionController', () => {
         }),
       );
     });
+    it('should bind a pairing invitation to the issued challenge', async () => {
+      const requestId = '019097ff-bb8c-75b3-a913-761d038cb9c0';
+      const session: Record<string, any> = {};
+      mockPairingService.bindInvitation.mockResolvedValueOnce({
+        pairingId: requestId,
+      } as any);
+      authService.search = jest
+        .fn()
+        .mockResolvedValue(assertionResponseResponseFixtures[0]);
+      await assertionController.request(
+        session,
+        assertionRequestParamFixtures[0],
+        {
+          ...assertionRequestBodyFixtures[0],
+          requestId,
+        } as PublicKeyCredentialRequestOptions,
+      );
+      expect(mockPairingService.bindInvitation).toHaveBeenCalledWith(requestId);
+      expect(session.pairingRequestId).toBe(requestId);
+    });
+    it('should proceed as legacy when a request id has no v2 invitation', async () => {
+      const requestId = 'legacy-request-123456789';
+      const session: Record<string, any> = {};
+      authService.search = jest
+        .fn()
+        .mockResolvedValue(assertionResponseResponseFixtures[0]);
+
+      await expect(
+        assertionController.request(session, assertionRequestParamFixtures[0], {
+          ...assertionRequestBodyFixtures[0],
+          requestId,
+        } as PublicKeyCredentialRequestOptions),
+      ).resolves.toEqual(
+        expect.objectContaining({ challenge: expect.any(String) }),
+      );
+      expect(session.pairingRequestId).toBeUndefined();
+    });
+    it('should propagate backend failures while looking up an invitation', async () => {
+      const failure = new Error('MongoDB is unavailable');
+      mockPairingService.bindInvitation.mockRejectedValueOnce(failure);
+      authService.search = jest
+        .fn()
+        .mockResolvedValue(assertionResponseResponseFixtures[0]);
+
+      await expect(
+        assertionController.request({}, assertionRequestParamFixtures[0], {
+          ...assertionRequestBodyFixtures[0],
+          requestId: 'legacy-request-123456789',
+        } as PublicKeyCredentialRequestOptions),
+      ).rejects.toBe(failure);
+    });
   });
 
   describe('POST /response', () => {
@@ -152,6 +213,125 @@ describe('AssertionController', () => {
           ).resolves.toStrictEqual(assertionResponseResponseFixtures[i]);
         }),
       );
+    });
+    it('should approve and return the challenge-bound pairing', async () => {
+      const savedUser = {
+        ...assertionResponseResponseFixtures[0],
+        credentials: [
+          {
+            ...assertionResponseResponseFixtures[0].credentials[0],
+            prevCounter:
+              assertionResponseResponseFixtures[0].credentials[0].prevCounter -
+              1,
+          },
+        ],
+      };
+      authService.search = jest.fn().mockResolvedValue(savedUser);
+      const body =
+        assertionResponseBodyFixtures[0] as unknown as AssertionCredentialJSON & {
+          clientExtensionResults: { liquid: { requestId: string } };
+        };
+      const requestId = body.clientExtensionResults.liquid.requestId;
+      const pairing = {
+        version: 2 as const,
+        pairingId: requestId,
+        role: 'controller' as const,
+        credential: 'controller-credential',
+      };
+      mockPairingService.approveInvitation.mockResolvedValueOnce(pairing);
+
+      await expect(
+        assertionController.response(
+          {
+            challenge: assertionRequestResponseFixtures[0].challenge,
+            pairingRequestId: requestId,
+          },
+          { 'user-agent': androidUserAgentFixtures[0] },
+          body,
+        ),
+      ).resolves.toEqual({
+        ...assertionResponseResponseFixtures[0],
+        pairing,
+      });
+      expect(mockPairingService.approveInvitation).toHaveBeenCalledWith(
+        requestId,
+        assertionResponseResponseFixtures[0].wallet,
+        body.id,
+      );
+    });
+    it('should approve a v2 pairing supplied only in a verified legacy response', async () => {
+      const savedUser = {
+        ...assertionResponseResponseFixtures[0],
+        credentials: [
+          {
+            ...assertionResponseResponseFixtures[0].credentials[0],
+            prevCounter:
+              assertionResponseResponseFixtures[0].credentials[0].prevCounter -
+              1,
+          },
+        ],
+      };
+      authService.search = jest.fn().mockResolvedValue(savedUser);
+      const body =
+        assertionResponseBodyFixtures[0] as unknown as AssertionCredentialJSON & {
+          clientExtensionResults: { liquid: { requestId: string } };
+        };
+      const requestId = body.clientExtensionResults.liquid.requestId;
+      const pairing = {
+        version: 2 as const,
+        pairingId: requestId,
+        role: 'controller' as const,
+        credential: 'controller-credential',
+      };
+      mockPairingService.bindInvitation.mockResolvedValueOnce({
+        pairingId: requestId,
+      } as any);
+      mockPairingService.approveInvitation.mockResolvedValueOnce(pairing);
+
+      await expect(
+        assertionController.response(
+          { challenge: assertionRequestResponseFixtures[0].challenge },
+          { 'user-agent': androidUserAgentFixtures[0] },
+          body,
+        ),
+      ).resolves.toEqual({
+        ...assertionResponseResponseFixtures[0],
+        pairing,
+      });
+      expect(mockPairingService.bindInvitation).toHaveBeenCalledWith(requestId);
+      expect(mockPairingService.approveInvitation).toHaveBeenCalledWith(
+        requestId,
+        assertionResponseResponseFixtures[0].wallet,
+        body.id,
+      );
+    });
+    it('should propagate backend failures for response-only pairing ids', async () => {
+      const savedUser = {
+        ...assertionResponseResponseFixtures[0],
+        credentials: [
+          {
+            ...assertionResponseResponseFixtures[0].credentials[0],
+            prevCounter:
+              assertionResponseResponseFixtures[0].credentials[0].prevCounter -
+              1,
+          },
+        ],
+      };
+      authService.search = jest.fn().mockResolvedValue(savedUser);
+      const failure = new Error('MongoDB is unavailable');
+      mockPairingService.bindInvitation.mockRejectedValueOnce(failure);
+      const body =
+        assertionResponseBodyFixtures[0] as unknown as AssertionCredentialJSON & {
+          clientExtensionResults: { liquid: { requestId: string } };
+        };
+
+      await expect(
+        assertionController.response(
+          { challenge: assertionRequestResponseFixtures[0].challenge },
+          { 'user-agent': androidUserAgentFixtures[0] },
+          body,
+        ),
+      ).rejects.toBe(failure);
     });
     it('should fail if the user is not found', async () => {
       await Promise.all(
@@ -232,6 +412,22 @@ describe('AssertionController', () => {
           session,
           req,
           dummyAssertionCredentialJSON,
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+    it('should reject a pairing response for a different challenge binding', async () => {
+      const body =
+        assertionResponseBodyFixtures[0] as unknown as AssertionCredentialJSON & {
+          clientExtensionResults: { liquid: { requestId: string } };
+        };
+      await expect(
+        assertionController.response(
+          {
+            challenge: assertionRequestResponseFixtures[0].challenge,
+            pairingRequestId: 'different-pairing-id',
+          },
+          { 'user-agent': androidUserAgentFixtures[0] },
+          body,
         ),
       ).rejects.toThrow(UnauthorizedException);
     });

--- a/src/assertion/assertion.controller.ts
+++ b/src/assertion/assertion.controller.ts
@@ -4,6 +4,7 @@ import {
   Headers,
   Inject,
   Logger,
+  NotFoundException,
   Param,
   Post,
   Session,
@@ -29,6 +30,36 @@ import {
 } from '@nestjs/swagger';
 import { User } from '../auth/auth.schema.js';
 import { AuthenticationResponseJSON } from '@simplewebauthn/server';
+import {
+  PairingApprovalResult,
+  PairingService,
+} from '../pairings/pairing.service.js';
+
+async function saveSession(session: Record<string, any>): Promise<void> {
+  if (typeof session?.save !== 'function') return;
+  await new Promise<void>((resolve, reject) => {
+    session.save((error?: Error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function responseWithPairing(user: any, pairing?: PairingApprovalResult) {
+  if (!pairing) return user;
+  const serialized =
+    typeof user?.toObject === 'function' ? user.toObject() : { ...user };
+  return { ...serialized, pairing };
+}
+
+async function bindPairingIfPresent(
+  pairingService: PairingService,
+  requestId: string,
+): Promise<string | undefined> {
+  try {
+    return (await pairingService.bindInvitation(requestId)).pairingId;
+  } catch (error) {
+    if (error instanceof NotFoundException) return undefined;
+    throw error;
+  }
+}
 // TODO: make a loader for descriptions
 const requestDescription = '';
 const responseDescription = '';
@@ -47,6 +78,7 @@ export class AssertionController {
     @Inject('ACCOUNT_LINK_SERVICE') private client: ClientProxy,
     private assertionService: AssertionService,
     private authService: AuthService,
+    private pairingService: PairingService,
   ) {}
 
   /**
@@ -93,10 +125,23 @@ export class AssertionController {
       });
     }
 
+    let pairingRequestId: string | undefined;
+    if (typeof body?.requestId === 'string') {
+      pairingRequestId = await bindPairingIfPresent(
+        this.pairingService,
+        body.requestId,
+      );
+    }
+
     // Get options, save challenge and respond
     const options = await this.assertionService.request(user, credId, body);
 
     session.challenge = options.challenge;
+    if (pairingRequestId) {
+      session.pairingRequestId = pairingRequestId;
+    } else {
+      delete session.pairingRequestId;
+    }
 
     this.logger.debug('Assertion Options', options);
     return options;
@@ -140,10 +185,21 @@ export class AssertionController {
     this.logger.log(`POST /response for Session: ${session.id}`);
     this.logger.debug('Authenticator Response', body);
     const expectedChallenge = session.challenge;
+    const boundRequestId = session.pairingRequestId as string | undefined;
+    const responseRequestId = body?.clientExtensionResults?.liquid?.requestId;
     if (typeof expectedChallenge !== 'string') {
       throw new UnauthorizedException({
         reason: 'unauthorized',
         error: 'Challenge not found.',
+      });
+    }
+    if (
+      typeof boundRequestId === 'string' &&
+      responseRequestId !== boundRequestId
+    ) {
+      throw new UnauthorizedException({
+        reason: 'unauthorized',
+        error: 'Pairing request does not match the issued challenge',
       });
     }
     const savedUser = await this.authService.search({
@@ -171,18 +227,36 @@ export class AssertionController {
       });
     }
 
+    const pairingRequestId =
+      boundRequestId ||
+      (typeof responseRequestId === 'string'
+        ? await bindPairingIfPresent(this.pairingService, responseRequestId)
+        : undefined);
+
     await this.authService.update(user);
+    const pairing =
+      typeof pairingRequestId === 'string'
+        ? await this.pairingService.approveInvitation(
+            pairingRequestId,
+            user.wallet,
+            body.id,
+          )
+        : undefined;
 
     delete session.challenge;
+    delete session.pairingRequestId;
     session.wallet = user.wallet;
+    await saveSession(session);
     // Emit the signin event for the given request id
-    this.client.emit<string>('auth', {
-      requestId: body?.clientExtensionResults?.liquid?.requestId,
+    const authEvent: Record<string, any> = {
+      requestId: pairingRequestId || responseRequestId,
       wallet: user.wallet,
       credId: body.id,
-      sessionId: session.id,
-    });
+    };
+    if (session.id) authEvent.sessionId = session.id;
+    if (pairing) authEvent.pairingId = pairing.pairingId;
+    this.client.emit<string>('auth', authEvent);
     this.logger.debug('User', user);
-    return user;
+    return responseWithPairing(user, pairing);
   }
 }

--- a/src/assertion/assertion.dto.ts
+++ b/src/assertion/assertion.dto.ts
@@ -35,6 +35,8 @@ export class AuthenticationExtensionsClientInputs {
 
 // Wrapped Implementations
 export class PublicKeyCredentialRequestOptions implements PublicKeyCredentialRequestOptionsType {
+  @ApiProperty({ required: false })
+  requestId?: string;
   @ApiProperty()
   allowCredentials: PublicKeyCredentialDescriptor[];
   @ApiProperty()

--- a/src/assertion/assertion.module.ts
+++ b/src/assertion/assertion.module.ts
@@ -8,10 +8,12 @@ import { User, UserSchema } from '../auth/auth.schema.js';
 import { AppService } from '../app.service.js';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import { Session, SessionSchema } from '../auth/session.schema.js';
+import { PairingModule } from '../pairings/pairing.module.js';
 
 @Module({
   imports: [
     ConfigModule,
+    PairingModule,
     MongooseModule.forFeature([
       { name: User.name, schema: UserSchema },
       { name: Session.name, schema: SessionSchema },

--- a/src/attestation/attestation.controller.spec.ts
+++ b/src/attestation/attestation.controller.spec.ts
@@ -10,7 +10,11 @@ import { mockAccountLinkService } from '../__mocks__/account-link.service.mock.j
 import { AppService } from '../app.service.js';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AttestationService } from './attestation.service.js';
-import { NotImplementedException, UnauthorizedException } from '@nestjs/common';
+import {
+  NotFoundException,
+  NotImplementedException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import {
   AttestationCredentialJSONDto,
   AttestationSelectorDto,
@@ -22,12 +26,17 @@ import attestationRequestResponseFixtures from './__fixtures__/attestation.reque
 import attestationRequestBodyFixtures from './__fixtures__/attestation.request.body.fixtures.json';
 import attestationResponseBodyFixtures from './__fixtures__/attestation.response.body.fixtures.json';
 import attestationResponseResponseFixtures from './__fixtures__/attestation.response.response.fixtures.json';
+import { PairingService } from '../pairings/pairing.service.js';
+import { mockPairingService } from '../__mocks__/pairing.service.mock.js';
 describe('AttestationController', () => {
   let attestationController: AttestationController;
   let userModel: Model<User>;
   let authService: AuthService;
   beforeEach(async () => {
     jest.resetAllMocks();
+    mockPairingService.bindInvitation.mockRejectedValue(
+      new NotFoundException('Pairing invitation not found or expired'),
+    );
     userModel = mongoose.model('User', UserSchema);
 
     const moduleRef: TestingModule = await Test.createTestingModule({
@@ -50,6 +59,10 @@ describe('AttestationController', () => {
         {
           provide: 'ACCOUNT_LINK_SERVICE',
           useValue: mockAccountLinkService,
+        },
+        {
+          provide: PairingService,
+          useValue: mockPairingService,
         },
         {
           provide: getModelToken(User.name),
@@ -103,6 +116,41 @@ describe('AttestationController', () => {
         ).rejects.toThrow(NotImplementedException);
       });
     });
+    it('should bind a pairing invitation to the issued challenge', async () => {
+      const requestId = '019097ff-bb8c-7514-a0c6-5209d2405a4a';
+      const session: Record<string, any> = {};
+      mockPairingService.bindInvitation.mockResolvedValueOnce({
+        pairingId: requestId,
+      } as any);
+      await attestationController.request(session, {
+        ...attestationRequestBodyFixtures[0],
+        requestId,
+      } as AttestationSelectorDto);
+      expect(mockPairingService.bindInvitation).toHaveBeenCalledWith(requestId);
+      expect(session.pairingRequestId).toBe(requestId);
+    });
+    it('should proceed as legacy when a request id has no v2 invitation', async () => {
+      const session: Record<string, any> = {};
+      await expect(
+        attestationController.request(session, {
+          ...attestationRequestBodyFixtures[0],
+          requestId: 'legacy-request-123456789',
+        } as AttestationSelectorDto),
+      ).resolves.toEqual(
+        expect.objectContaining({ challenge: expect.any(String) }),
+      );
+      expect(session.pairingRequestId).toBeUndefined();
+    });
+    it('should propagate backend failures while looking up an invitation', async () => {
+      const failure = new Error('MongoDB is unavailable');
+      mockPairingService.bindInvitation.mockRejectedValueOnce(failure);
+      await expect(
+        attestationController.request({}, {
+          ...attestationRequestBodyFixtures[0],
+          requestId: 'legacy-request-123456789',
+        } as AttestationSelectorDto),
+      ).rejects.toBe(failure);
+    });
   });
 
   describe('POST /response', () => {
@@ -129,6 +177,96 @@ describe('AttestationController', () => {
         wallet: body.clientExtensionResults.liquid.address,
         credId: body.id,
       });
+    });
+    it('should approve and return the challenge-bound pairing', async () => {
+      const session: Record<string, any> = new Session();
+      const user = attestationResponseResponseFixtures[0];
+      const body =
+        attestationResponseBodyFixtures[0] as AttestationCredentialJSONDto;
+      const requestId = body.clientExtensionResults.liquid.requestId;
+      const pairing = {
+        version: 2 as const,
+        pairingId: requestId,
+        role: 'controller' as const,
+        credential: 'controller-credential',
+      };
+      authService.addCredential = jest.fn().mockResolvedValue(user);
+      mockPairingService.approveInvitation.mockResolvedValueOnce(pairing);
+      session.challenge = attestationRequestResponseFixtures[0].challenge;
+      session.liquidExtension = true;
+      session.pairingRequestId = requestId;
+
+      await expect(
+        attestationController.response(
+          session,
+          { 'user-agent': androidUserAgentFixtures[0] },
+          body,
+        ),
+      ).resolves.toEqual({ ...user, pairing });
+      expect(mockPairingService.approveInvitation).toHaveBeenCalledWith(
+        requestId,
+        user.wallet,
+        body.id,
+      );
+      expect(mockAccountLinkService.emit).toHaveBeenCalledWith(
+        'auth',
+        expect.objectContaining({
+          requestId,
+          pairingId: requestId,
+          wallet: user.wallet,
+        }),
+      );
+    });
+    it('should approve a v2 pairing supplied only in a verified legacy response', async () => {
+      const session: Record<string, any> = new Session();
+      const user = attestationResponseResponseFixtures[0];
+      const body =
+        attestationResponseBodyFixtures[0] as AttestationCredentialJSONDto;
+      const requestId = body.clientExtensionResults.liquid.requestId;
+      const pairing = {
+        version: 2 as const,
+        pairingId: requestId,
+        role: 'controller' as const,
+        credential: 'controller-credential',
+      };
+      authService.addCredential = jest.fn().mockResolvedValue(user);
+      mockPairingService.bindInvitation.mockResolvedValueOnce({
+        pairingId: requestId,
+      } as any);
+      mockPairingService.approveInvitation.mockResolvedValueOnce(pairing);
+      session.challenge = attestationRequestResponseFixtures[0].challenge;
+      session.liquidExtension = true;
+
+      await expect(
+        attestationController.response(
+          session,
+          { 'user-agent': androidUserAgentFixtures[0] },
+          body,
+        ),
+      ).resolves.toEqual({ ...user, pairing });
+      expect(mockPairingService.bindInvitation).toHaveBeenCalledWith(requestId);
+      expect(mockPairingService.approveInvitation).toHaveBeenCalledWith(
+        requestId,
+        user.wallet,
+        body.id,
+      );
+    });
+    it('should propagate backend failures for response-only pairing ids', async () => {
+      const session: Record<string, any> = new Session();
+      const body =
+        attestationResponseBodyFixtures[0] as AttestationCredentialJSONDto;
+      const failure = new Error('MongoDB is unavailable');
+      mockPairingService.bindInvitation.mockRejectedValueOnce(failure);
+      session.challenge = attestationRequestResponseFixtures[0].challenge;
+      session.liquidExtension = true;
+
+      await expect(
+        attestationController.response(
+          session,
+          { 'user-agent': androidUserAgentFixtures[0] },
+          body,
+        ),
+      ).rejects.toBe(failure);
     });
     it('should set a default device if empty', async () => {
       const session: Record<string, any> = new Session();
@@ -207,6 +345,21 @@ describe('AttestationController', () => {
           ).rejects.toThrow(UnauthorizedException);
         }),
       );
+    });
+    it('should reject a pairing response for a different challenge binding', async () => {
+      const body =
+        attestationResponseBodyFixtures[0] as AttestationCredentialJSONDto;
+      await expect(
+        attestationController.response(
+          {
+            challenge: attestationRequestResponseFixtures[0].challenge,
+            liquidExtension: true,
+            pairingRequestId: 'different-pairing-id',
+          },
+          { 'user-agent': androidUserAgentFixtures[0] },
+          body,
+        ),
+      ).rejects.toThrow(UnauthorizedException);
     });
     it(`should fail when the extension data is invalid`, async () => {
       await Promise.all(

--- a/src/attestation/attestation.controller.ts
+++ b/src/attestation/attestation.controller.ts
@@ -5,6 +5,7 @@ import {
   Logger,
   Post,
   Headers,
+  NotFoundException,
   Session,
   UnauthorizedException,
   NotImplementedException,
@@ -18,6 +19,36 @@ import {
   AttestationCredentialJSONDto,
   AttestationSelectorDto,
 } from './attestation.dto.js';
+import {
+  PairingApprovalResult,
+  PairingService,
+} from '../pairings/pairing.service.js';
+
+async function saveSession(session: Record<string, any>): Promise<void> {
+  if (typeof session?.save !== 'function') return;
+  await new Promise<void>((resolve, reject) => {
+    session.save((error?: Error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function responseWithPairing(user: any, pairing?: PairingApprovalResult) {
+  if (!pairing) return user;
+  const serialized =
+    typeof user?.toObject === 'function' ? user.toObject() : { ...user };
+  return { ...serialized, pairing };
+}
+
+async function bindPairingIfPresent(
+  pairingService: PairingService,
+  requestId: string,
+): Promise<string | undefined> {
+  try {
+    return (await pairingService.bindInvitation(requestId)).pairingId;
+  } catch (error) {
+    if (error instanceof NotFoundException) return undefined;
+    throw error;
+  }
+}
 
 @Controller('attestation')
 @ApiTags('attestation')
@@ -27,6 +58,7 @@ export class AttestationController {
     @Inject('ACCOUNT_LINK_SERVICE') private client: ClientProxy,
     private attestationService: AttestationService,
     private authService: AuthService,
+    private pairingService: PairingService,
   ) {}
   /**
    * Request Attestation Options
@@ -54,11 +86,23 @@ export class AttestationController {
         error: 'Liquid extension is required',
       });
     }
-    session.liquidExtension = true;
+    let pairingRequestId: string | undefined;
+    if (typeof options.requestId === 'string') {
+      pairingRequestId = await bindPairingIfPresent(
+        this.pairingService,
+        options.requestId,
+      );
+    }
     // Request Attestation Options
     const attestationOptions = await this.attestationService.request(options);
     // This challenge is used to verify the response
+    session.liquidExtension = true;
     session.challenge = attestationOptions.challenge;
+    if (pairingRequestId) {
+      session.pairingRequestId = pairingRequestId;
+    } else {
+      delete session.pairingRequestId;
+    }
     // Return the Attestation Options
     this.logger.debug('Attestation Options', attestationOptions);
     return attestationOptions;
@@ -87,11 +131,22 @@ export class AttestationController {
     // Session state
     const isLiquid = session.liquidExtension || false;
     const expectedChallenge = session.challenge;
+    const boundRequestId = session.pairingRequestId as string | undefined;
+    const responseRequestId = body?.clientExtensionResults?.liquid?.requestId;
     // This request should only be called after a request
     if (typeof expectedChallenge !== 'string') {
       throw new UnauthorizedException({
         reason: 'unauthorized',
         error: 'Challenge not found',
+      });
+    }
+    if (
+      typeof boundRequestId === 'string' &&
+      responseRequestId !== boundRequestId
+    ) {
+      throw new UnauthorizedException({
+        reason: 'unauthorized',
+        error: 'Pairing request does not match the issued challenge',
       });
     }
     // If the liquid extension is enabled, the client must send the liquid extension
@@ -122,27 +177,43 @@ export class AttestationController {
         });
       });
 
+    const pairingRequestId =
+      boundRequestId ||
+      (typeof responseRequestId === 'string'
+        ? await bindPairingIfPresent(this.pairingService, responseRequestId)
+        : undefined);
+
     const username = body.clientExtensionResults.liquid.address;
     // Initialize a new user if it doesn't exist
     await this.authService.init(username);
     // Add the new credential to the user
     const user = await this.authService.addCredential(username, credential);
+    const pairing =
+      typeof pairingRequestId === 'string'
+        ? await this.pairingService.approveInvitation(
+            pairingRequestId,
+            user.wallet,
+            credential.credId,
+          )
+        : undefined;
     // Cleanup Session
     delete session.liquidExtension;
     delete session.challenge;
+    delete session.pairingRequestId;
     // Authorize user with a wallet session
     session.wallet = username;
+    await saveSession(session);
     // Handle Liquid Extension
-    this.client.emit<string>('auth', {
-      requestId: body?.clientExtensionResults?.liquid?.requestId,
+    const authEvent: Record<string, any> = {
+      requestId: pairingRequestId || responseRequestId,
       wallet: user.wallet,
       credId: credential.credId,
-      sessionId: session.id,
-    });
-
-    console.log('session', session);
+    };
+    if (session.id) authEvent.sessionId = session.id;
+    if (pairing) authEvent.pairingId = pairing.pairingId;
+    this.client.emit<string>('auth', authEvent);
 
     this.logger.debug('User', user);
-    return user;
+    return responseWithPairing(user, pairing);
   }
 }

--- a/src/attestation/attestation.dto.ts
+++ b/src/attestation/attestation.dto.ts
@@ -1,6 +1,7 @@
 import type { RegistrationResponseJSON } from '@simplewebauthn/server';
 
 export type AttestationSelectorDto = {
+  requestId?: string;
   username: string;
   displayName: string;
   authenticatorSelection: AuthenticatorSelectionCriteria;

--- a/src/attestation/attestation.module.ts
+++ b/src/attestation/attestation.module.ts
@@ -9,10 +9,12 @@ import { User, UserSchema } from '../auth/auth.schema.js';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import { Session, SessionSchema } from '../auth/session.schema.js';
 import { AlgodService } from '../algod/algod.service.js';
+import { PairingModule } from '../pairings/pairing.module.js';
 
 @Module({
   imports: [
     ConfigModule,
+    PairingModule,
     MongooseModule.forFeature([
       { name: User.name, schema: UserSchema },
       { name: Session.name, schema: SessionSchema },

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -1,8 +1,33 @@
 import configFactory from './configuration.js';
 import configFixture from '../__fixtures__/configuration.fixture.json';
+
+const productionSessionSecret = '01-session-5d8d64ad-e164-4cd4-987a';
+const productionPairingSecret = '02-pairing-6296c079-f29c-4715-803b';
+
 describe('configuration', () => {
-  it('should return the configuration', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalSessionSecret = process.env.SESSION_SECRET;
+  const originalPairingCredentialSecret = process.env.PAIRING_CREDENTIAL_SECRET;
+
+  beforeEach(() => {
     delete process.env.NODE_ENV;
+    delete process.env.SESSION_SECRET;
+    delete process.env.PAIRING_CREDENTIAL_SECRET;
+  });
+
+  afterAll(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    if (originalSessionSecret === undefined) delete process.env.SESSION_SECRET;
+    else process.env.SESSION_SECRET = originalSessionSecret;
+    if (originalPairingCredentialSecret === undefined) {
+      delete process.env.PAIRING_CREDENTIAL_SECRET;
+    } else {
+      process.env.PAIRING_CREDENTIAL_SECRET = originalPairingCredentialSecret;
+    }
+  });
+
+  it('should return the configuration', () => {
     expect(configFactory()).toEqual({
       ...configFixture,
       env: 'development',
@@ -10,6 +35,72 @@ describe('configuration', () => {
       origin: 'http://localhost',
       enableIndexPage: false,
     });
+  });
+
+  it('keeps development and tests usable without configured secrets', () => {
     process.env.NODE_ENV = 'test';
+
+    expect(configFactory()).toEqual(
+      expect.objectContaining({
+        session: expect.objectContaining({ secret: 'secret' }),
+        pairing: expect.objectContaining({ credentialSecret: 'secret' }),
+      }),
+    );
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['placeholder', 'replace-me'],
+    ['template-placeholder', '<FIRST_INDEPENDENT_RANDOM_VALUE>'],
+    ['weak', 'short-production-secret'],
+    ['low-diversity', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+  ])('rejects a %s production session secret', (_label, value) => {
+    process.env.NODE_ENV = 'production';
+    if (value !== undefined) process.env.SESSION_SECRET = value;
+    process.env.PAIRING_CREDENTIAL_SECRET = productionPairingSecret;
+
+    expect(() => configFactory()).toThrow(/SESSION_SECRET/);
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['placeholder', 'replace-with-an-independent-secret'],
+    ['template-placeholder', '<SECOND_INDEPENDENT_RANDOM_VALUE>'],
+    ['weak', 'short-production-secret'],
+    ['low-diversity', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+  ])('rejects a %s production pairing secret', (_label, value) => {
+    process.env.NODE_ENV = 'production';
+    process.env.SESSION_SECRET = productionSessionSecret;
+    if (value !== undefined) process.env.PAIRING_CREDENTIAL_SECRET = value;
+
+    expect(() => configFactory()).toThrow(/PAIRING_CREDENTIAL_SECRET/);
+  });
+
+  it('requires independent production session and pairing secrets', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.SESSION_SECRET = productionSessionSecret;
+    process.env.PAIRING_CREDENTIAL_SECRET = productionSessionSecret;
+
+    expect(() => configFactory()).toThrow(
+      'PAIRING_CREDENTIAL_SECRET must be independent from SESSION_SECRET',
+    );
+  });
+
+  it('accepts strong, independent production secrets', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.SESSION_SECRET = productionSessionSecret;
+    process.env.PAIRING_CREDENTIAL_SECRET = productionPairingSecret;
+
+    expect(configFactory()).toEqual(
+      expect.objectContaining({
+        env: 'production',
+        session: expect.objectContaining({
+          secret: productionSessionSecret,
+        }),
+        pairing: expect.objectContaining({
+          credentialSecret: productionPairingSecret,
+        }),
+      }),
+    );
   });
 });

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,32 +1,134 @@
 import * as process from 'node:process';
 
-export default () => ({
-  env: process.env.NODE_ENV || 'development',
-  timeout: 30 * 1000 * 60,
-  rpName: process.env.RP_NAME || 'Algorand Foundation FIDO2 Server',
-  hostname: process.env.HOSTNAME || 'localhost',
-  origin: process.env.ORIGIN || 'http://localhost',
-  enableIndexPage: process.env.ENABLE_INDEX_PAGE === 'true',
-  session: {
-    secure: process.env.SESSION_SECURE === 'true',
-    secret: process.env.SESSION_SECRET || 'secret',
-  },
-  socket: {
-    host: process.env.REDIS_HOST || 'localhost',
-    port: parseInt(process.env.REDIS_PORT, 10) || 6379,
-    username: process.env.REDIS_USERNAME || 'default',
-    password: process.env.REDIS_PASSWORD || '',
-  },
-  database: {
-    host: process.env.DB_HOST || 'localhost:27017',
-    username: process.env.DB_USERNAME || 'algorand',
-    password: process.env.DB_PASSWORD || 'algorand',
-    name: process.env.DB_NAME || 'fido',
-    atlas: process.env.DB_ATLAS === 'true',
-  },
-  algod: {
-    token: process.env.ALGOD_TOKEN || '',
-    server: process.env.ALGOD_SERVER || 'https://testnet-api.algonode.cloud',
-    port: process.env.ALGOD_PORT || '443',
-  },
-});
+const MINIMUM_PRODUCTION_SECRET_LENGTH = 32;
+
+function productionSecret(name: string): string {
+  const value = process.env[name];
+  const normalized = value
+    ?.trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-');
+
+  if (!value?.trim()) {
+    throw new Error(`${name} must be explicitly configured in production`);
+  }
+  if (
+    value.includes('<') ||
+    value.includes('>') ||
+    normalized === 'secret' ||
+    normalized === 'password' ||
+    normalized === 'default' ||
+    normalized === 'development' ||
+    normalized === 'test' ||
+    normalized === 'session-secret' ||
+    normalized === 'pairing-credential-secret' ||
+    normalized?.includes('changeme') ||
+    normalized?.includes('password') ||
+    normalized?.includes('your-secret') ||
+    normalized?.includes('example') ||
+    normalized?.startsWith('replace-') ||
+    normalized?.startsWith('change-me') ||
+    normalized?.includes('placeholder')
+  ) {
+    throw new Error(`${name} must not use a placeholder value in production`);
+  }
+  if (
+    value.length < MINIMUM_PRODUCTION_SECRET_LENGTH ||
+    new Set(value).size < 8
+  ) {
+    throw new Error(
+      `${name} must be a strong secret of at least ${MINIMUM_PRODUCTION_SECRET_LENGTH} characters in production`,
+    );
+  }
+  return value;
+}
+
+function secrets(environment: string): {
+  sessionSecret: string;
+  pairingCredentialSecret: string;
+} {
+  if (environment !== 'production') {
+    const sessionSecret = process.env.SESSION_SECRET || 'secret';
+    return {
+      sessionSecret,
+      pairingCredentialSecret:
+        process.env.PAIRING_CREDENTIAL_SECRET || sessionSecret,
+    };
+  }
+
+  const sessionSecret = productionSecret('SESSION_SECRET');
+  const pairingCredentialSecret = productionSecret('PAIRING_CREDENTIAL_SECRET');
+  if (pairingCredentialSecret === sessionSecret) {
+    throw new Error(
+      'PAIRING_CREDENTIAL_SECRET must be independent from SESSION_SECRET in production',
+    );
+  }
+  return { sessionSecret, pairingCredentialSecret };
+}
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function corsOrigins(): string[] {
+  const configured =
+    process.env.CORS_ORIGINS || process.env.ORIGIN || 'http://localhost';
+  return configured
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+export default () => {
+  const environment = process.env.NODE_ENV || 'development';
+  const { sessionSecret, pairingCredentialSecret } = secrets(environment);
+
+  return {
+    env: environment,
+    timeout: 30 * 1000 * 60,
+    rpName: process.env.RP_NAME || 'Algorand Foundation FIDO2 Server',
+    hostname: process.env.HOSTNAME || 'localhost',
+    origin: process.env.ORIGIN || 'http://localhost',
+    enableIndexPage: process.env.ENABLE_INDEX_PAGE === 'true',
+    session: {
+      secure: process.env.SESSION_SECURE === 'true',
+      secret: sessionSecret,
+      ttlSeconds: positiveInteger(process.env.SESSION_TTL_SECONDS, 20000),
+      cookieMaxAgeMs: positiveInteger(
+        process.env.SESSION_COOKIE_MAX_AGE_MS,
+        20000 * 1000,
+      ),
+      sameSite: process.env.SESSION_SAME_SITE || 'lax',
+      trustProxy: process.env.TRUST_PROXY === 'true',
+    },
+    cors: {
+      origins: corsOrigins(),
+    },
+    pairing: {
+      credentialSecret: pairingCredentialSecret,
+      invitationTtlSeconds: positiveInteger(
+        process.env.PAIRING_INVITATION_TTL_SECONDS,
+        900,
+      ),
+    },
+    socket: {
+      host: process.env.REDIS_HOST || 'localhost',
+      port: parseInt(process.env.REDIS_PORT, 10) || 6379,
+      username: process.env.REDIS_USERNAME || 'default',
+      password: process.env.REDIS_PASSWORD || '',
+    },
+    database: {
+      host: process.env.DB_HOST || 'localhost:27017',
+      username: process.env.DB_USERNAME || 'algorand',
+      password: process.env.DB_PASSWORD || 'algorand',
+      name: process.env.DB_NAME || 'fido',
+      atlas: process.env.DB_ATLAS === 'true',
+    },
+    algod: {
+      token: process.env.ALGOD_TOKEN || '',
+      server: process.env.ALGOD_SERVER || 'https://testnet-api.algonode.cloud',
+      port: process.env.ALGOD_PORT || '443',
+    },
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './app.module.js';
 export * from './app.service.js';
 export * from './sentry.filter.js';
 export * from './adapters/redis-io.adapter.js';
+export * from './pairings/index.js';

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,13 @@ async function bootstrap() {
     logger: ['error', 'warn', 'debug', 'log', 'verbose'],
   });
   const config = app.get<ConfigService>(ConfigService);
+  if (config.get<boolean>('session.trustProxy')) {
+    app.set('trust proxy', 1);
+  }
+  app.enableCors({
+    origin: config.get<string[]>('cors.origins') || [],
+    credentials: true,
+  });
 
   const isSentryEnabled =
     config.get('sentry') || typeof process.env.SENTRY_DNS !== 'undefined';
@@ -57,17 +64,22 @@ async function bootstrap() {
 
   const store = MongoStore.create({
     mongoUrl: uri,
-    ttl: 20000,
+    ttl: config.get<number>('session.ttlSeconds'),
   });
 
   const sessionHandler = session({
     secret: config.get('session.secret'),
-    // TODO: optimize session
+    // Legacy clients still need an initial session during the Socket.IO
+    // handshake. Durable v2 pairing authorization does not depend on it.
     saveUninitialized: true,
-    resave: true,
+    resave: false,
+    rolling: true,
+    proxy: config.get<boolean>('session.trustProxy'),
     cookie: {
       httpOnly: true,
       secure: config.get('session.secure'),
+      maxAge: config.get<number>('session.cookieMaxAgeMs'),
+      sameSite: config.get('session.sameSite'),
     },
     store,
   });

--- a/src/pairings/index.ts
+++ b/src/pairings/index.ts
@@ -1,0 +1,4 @@
+export * from './pairing-invitation.schema.js';
+export * from './pairing.schema.js';
+export * from './pairing.service.js';
+export * from './pairing.module.js';

--- a/src/pairings/pairing-invitation.schema.ts
+++ b/src/pairings/pairing-invitation.schema.ts
@@ -1,0 +1,41 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type PairingInvitationDocument = HydratedDocument<PairingInvitation>;
+export type PairingInvitationStatus = 'pending' | 'consumed' | 'revoked';
+
+@Schema({ timestamps: true })
+export class PairingInvitation {
+  @Prop({ required: true, unique: true, index: true })
+  pairingId: string;
+
+  @Prop({ required: true, unique: true, index: true })
+  requestId: string;
+
+  @Prop({ required: true })
+  providerCredentialHash: string;
+
+  /**
+   * Pending/consumed invitations expire through this TTL field. Revocation
+   * unsets it so the authenticated tombstone is retained indefinitely.
+   */
+  @Prop({ index: { expireAfterSeconds: 0 } })
+  expiresAt?: Date;
+
+  @Prop({
+    enum: ['pending', 'consumed', 'revoked'],
+  })
+  status?: PairingInvitationStatus;
+
+  @Prop()
+  consumedAt?: Date;
+
+  @Prop()
+  revokedAt?: Date;
+
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export const PairingInvitationSchema =
+  SchemaFactory.createForClass(PairingInvitation);

--- a/src/pairings/pairing.controller.spec.ts
+++ b/src/pairings/pairing.controller.spec.ts
@@ -1,0 +1,119 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { PairingController } from './pairing.controller.js';
+import { PairingService } from './pairing.service.js';
+import { ClientProxy } from '@nestjs/microservices';
+
+describe('PairingController', () => {
+  const pairingService = {
+    createInvitation: jest.fn(),
+    authenticateCredential: jest.fn(),
+    revoke: jest.fn(),
+  } as unknown as PairingService;
+  const accountLinkService = {
+    emit: jest.fn(),
+  } as unknown as ClientProxy;
+  const controller = new PairingController(pairingService, accountLinkService);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('creates an invitation with an optional caller request id', async () => {
+    const invitation = {
+      version: 2,
+      pairingId: 'pairing-123456789',
+      role: 'provider',
+      credential: 'provider-credential',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    (pairingService.createInvitation as jest.Mock).mockResolvedValue(
+      invitation,
+    );
+
+    await expect(
+      controller.createInvitation({ requestId: invitation.pairingId }),
+    ).resolves.toEqual(invitation);
+    expect(pairingService.createInvitation).toHaveBeenCalledWith(
+      invitation.pairingId,
+    );
+  });
+
+  it('authenticates status requests with a role-bound bearer credential', async () => {
+    (pairingService.authenticateCredential as jest.Mock).mockResolvedValue({
+      version: 2,
+      pairingId: 'pairing-123456789',
+      role: 'provider',
+      status: 'active',
+      wallet: 'WALLET',
+    });
+
+    await controller.status(
+      'pairing-123456789',
+      'Bearer provider-credential',
+      'provider',
+    );
+    expect(pairingService.authenticateCredential).toHaveBeenCalledWith(
+      'pairing-123456789',
+      'provider',
+      'provider-credential',
+      true,
+    );
+  });
+
+  it('rejects missing or invalid role-bound credentials', async () => {
+    await expect(
+      controller.status('pairing-123456789', '', 'provider'),
+    ).rejects.toThrow(UnauthorizedException);
+    await expect(
+      controller.revoke(
+        'pairing-123456789',
+        'Bearer provider-credential',
+        'unexpected-role',
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('allows either paired role to revoke with its own credential', async () => {
+    (pairingService.revoke as jest.Mock).mockResolvedValue({
+      version: 2,
+      pairingId: 'pairing-123456789',
+      status: 'revoked',
+    });
+    await controller.revoke(
+      'pairing-123456789',
+      'Bearer controller-credential',
+      'controller',
+    );
+    expect(pairingService.revoke).toHaveBeenCalledWith(
+      'pairing-123456789',
+      'controller',
+      'controller-credential',
+    );
+    expect(accountLinkService.emit).toHaveBeenCalledWith('auth', {
+      type: 'pairing:revoked',
+      version: 2,
+      pairingId: 'pairing-123456789',
+      status: 'revoked',
+    });
+  });
+
+  it('rebroadcasts an idempotent revocation retry', async () => {
+    (pairingService.revoke as jest.Mock).mockResolvedValue({
+      version: 2,
+      pairingId: 'pairing-123456789',
+      status: 'revoked',
+    });
+
+    await controller.revoke(
+      'pairing-123456789',
+      'Bearer provider-credential',
+      'provider',
+    );
+    await controller.revoke(
+      'pairing-123456789',
+      'Bearer provider-credential',
+      'provider',
+    );
+
+    expect(pairingService.revoke).toHaveBeenCalledTimes(2);
+    expect(accountLinkService.emit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/pairings/pairing.controller.ts
+++ b/src/pairings/pairing.controller.ts
@@ -1,0 +1,83 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Headers,
+  Inject,
+  Param,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ClientProxy } from '@nestjs/microservices';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { PairingRole } from './pairing.schema.js';
+import { PairingService } from './pairing.service.js';
+
+@Controller('pairings')
+@ApiTags('pairings')
+export class PairingController {
+  constructor(
+    private readonly pairingService: PairingService,
+    @Inject('ACCOUNT_LINK_SERVICE') private readonly client: ClientProxy,
+  ) {}
+
+  @Post('/invitations')
+  @ApiOperation({ summary: 'Create a durable pairing invitation' })
+  async createInvitation(@Body() body: { requestId?: string } = {}) {
+    return this.pairingService.createInvitation(body?.requestId);
+  }
+
+  @Get('/:pairingId/status')
+  @ApiOperation({ summary: 'Read durable pairing status' })
+  async status(
+    @Param('pairingId') pairingId: string,
+    @Headers('authorization') authorization: string,
+    @Headers('x-pairing-role') roleHeader: string,
+  ) {
+    const { credential, role } = this.readCredentials(
+      authorization,
+      roleHeader,
+    );
+    return this.pairingService.authenticateCredential(
+      pairingId,
+      role,
+      credential,
+      true,
+    );
+  }
+
+  @Delete('/:pairingId')
+  @ApiOperation({ summary: 'Revoke a durable pairing' })
+  async revoke(
+    @Param('pairingId') pairingId: string,
+    @Headers('authorization') authorization: string,
+    @Headers('x-pairing-role') roleHeader: string,
+  ) {
+    const { credential, role } = this.readCredentials(
+      authorization,
+      roleHeader,
+    );
+    const result = await this.pairingService.revoke(
+      pairingId,
+      role,
+      credential,
+    );
+    this.client.emit<string>('auth', {
+      type: 'pairing:revoked',
+      ...result,
+    });
+    return result;
+  }
+
+  private readCredentials(
+    authorization: string,
+    roleHeader: string,
+  ): { credential: string; role: PairingRole } {
+    const match = /^Bearer\s+(.+)$/i.exec(authorization || '');
+    if (!match || (roleHeader !== 'provider' && roleHeader !== 'controller')) {
+      throw new UnauthorizedException('Pairing credentials are required');
+    }
+    return { credential: match[1], role: roleHeader };
+  }
+}

--- a/src/pairings/pairing.module.ts
+++ b/src/pairings/pairing.module.ts
@@ -1,0 +1,35 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ClientsModule, Transport } from '@nestjs/microservices';
+import {
+  PairingInvitation,
+  PairingInvitationSchema,
+} from './pairing-invitation.schema.js';
+import { Pairing, PairingSchema } from './pairing.schema.js';
+import { PairingController } from './pairing.controller.js';
+import { PairingService } from './pairing.service.js';
+
+@Module({
+  imports: [
+    ClientsModule.register([
+      {
+        name: 'ACCOUNT_LINK_SERVICE',
+        transport: Transport.REDIS,
+        options: {
+          host: process.env.REDIS_HOST || 'localhost',
+          port: parseInt(process.env.REDIS_PORT, 10) || 6379,
+          username: process.env.REDIS_USERNAME || 'default',
+          password: process.env.REDIS_PASSWORD || '',
+        },
+      },
+    ]),
+    MongooseModule.forFeature([
+      { name: PairingInvitation.name, schema: PairingInvitationSchema },
+      { name: Pairing.name, schema: PairingSchema },
+    ]),
+  ],
+  controllers: [PairingController],
+  providers: [PairingService],
+  exports: [PairingService],
+})
+export class PairingModule {}

--- a/src/pairings/pairing.schema.ts
+++ b/src/pairings/pairing.schema.ts
@@ -1,0 +1,35 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type PairingRole = 'provider' | 'controller';
+export type PairingStatus = 'active' | 'revoked';
+export type PairingDocument = HydratedDocument<Pairing>;
+
+@Schema({ timestamps: true })
+export class Pairing {
+  @Prop({ required: true, unique: true, index: true })
+  pairingId: string;
+
+  @Prop({ required: true, index: true })
+  wallet: string;
+
+  @Prop({ required: true })
+  providerCredentialHash: string;
+
+  @Prop({ required: true })
+  controllerCredentialHash: string;
+
+  @Prop({ required: true, enum: ['active', 'revoked'], default: 'active' })
+  status: PairingStatus;
+
+  @Prop({ required: true })
+  approvingCredentialId: string;
+
+  @Prop()
+  revokedAt?: Date;
+
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+export const PairingSchema = SchemaFactory.createForClass(Pairing);

--- a/src/pairings/pairing.service.spec.ts
+++ b/src/pairings/pairing.service.spec.ts
@@ -1,0 +1,379 @@
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Model } from 'mongoose';
+import {
+  PairingInvitation,
+  PairingInvitationSchema,
+} from './pairing-invitation.schema.js';
+import { Pairing } from './pairing.schema.js';
+import {
+  PairingAuthorizationError,
+  PairingService,
+} from './pairing.service.js';
+
+type StoredDocument = Record<string, any>;
+
+function matches(document: StoredDocument, query: StoredDocument): boolean {
+  return Object.entries(query).every(([key, expected]) => {
+    if (key === '$or') {
+      return (expected as StoredDocument[]).some((candidate) =>
+        matches(document, candidate),
+      );
+    }
+    if (key === '$and') {
+      return (expected as StoredDocument[]).every((candidate) =>
+        matches(document, candidate),
+      );
+    }
+    const actual = document[key];
+    if (
+      expected &&
+      typeof expected === 'object' &&
+      !(expected instanceof Date)
+    ) {
+      const operators = expected as StoredDocument;
+      if (
+        '$exists' in operators &&
+        (actual !== undefined) !== operators.$exists
+      ) {
+        return false;
+      }
+      if ('$gt' in operators && !(actual > operators.$gt)) return false;
+      return true;
+    }
+    return actual === expected;
+  });
+}
+
+function queryResult<T>(result: T) {
+  return { exec: jest.fn().mockResolvedValue(result) };
+}
+
+function applyUpdate(document: StoredDocument, update: StoredDocument): void {
+  if ('$set' in update || '$unset' in update) {
+    Object.assign(document, update.$set || {});
+    for (const key of Object.keys(update.$unset || {})) delete document[key];
+    return;
+  }
+  Object.assign(document, update);
+}
+
+describe('PairingService', () => {
+  let invitations: StoredDocument[];
+  let pairings: StoredDocument[];
+  let invitationModel: any;
+  let pairingModel: any;
+  let service: PairingService;
+
+  beforeEach(() => {
+    invitations = [];
+    pairings = [];
+
+    invitationModel = jest.fn(function (
+      this: StoredDocument,
+      values: StoredDocument,
+    ) {
+      Object.assign(this, values);
+      this.save = jest.fn(async () => {
+        invitations.push(this);
+        return this;
+      });
+    });
+    invitationModel.findOne = jest.fn((query) =>
+      queryResult(invitations.find((item) => matches(item, query)) || null),
+    );
+    invitationModel.findOneAndUpdate = jest.fn((query, update) => {
+      const invitation = invitations.find((item) => matches(item, query));
+      if (invitation) applyUpdate(invitation, update);
+      return queryResult(invitation || null);
+    });
+    invitationModel.deleteOne = jest.fn((query) => {
+      const index = invitations.findIndex((item) => matches(item, query));
+      if (index >= 0) invitations.splice(index, 1);
+      return queryResult({ deletedCount: index >= 0 ? 1 : 0 });
+    });
+
+    pairingModel = jest.fn(function (
+      this: StoredDocument,
+      values: StoredDocument,
+    ) {
+      Object.assign(this, values);
+      this.save = jest.fn(async () => {
+        pairings.push(this);
+        return this;
+      });
+    });
+    pairingModel.findOne = jest.fn((query) =>
+      queryResult(pairings.find((item) => matches(item, query)) || null),
+    );
+    pairingModel.findOneAndUpdate = jest.fn((query, update) => {
+      const pairing = pairings.find((item) => matches(item, query));
+      if (pairing) applyUpdate(pairing, update);
+      return queryResult(pairing || null);
+    });
+
+    const config = {
+      get: jest.fn((key: string) => {
+        if (key === 'pairing.credentialSecret') return 'pairing-test-secret';
+        if (key === 'pairing.invitationTtlSeconds') return 900;
+        return undefined;
+      }),
+    } as unknown as ConfigService;
+    service = new PairingService(
+      invitationModel as Model<PairingInvitation>,
+      pairingModel as Model<Pairing>,
+      config,
+    );
+  });
+
+  it('retains the deployed expiresAt TTL index used by legacy invitations', () => {
+    expect(PairingInvitationSchema.indexes()).toContainEqual([
+      { expiresAt: 1 },
+      { expireAfterSeconds: 0 },
+    ]);
+  });
+
+  it('creates a pending invitation authenticated by an HMAC-stored provider credential', async () => {
+    const result = await service.createInvitation('pairing-123456789');
+    expect(result).toEqual({
+      version: 2,
+      pairingId: 'pairing-123456789',
+      role: 'provider',
+      credential: expect.any(String),
+      expiresAt: expect.any(String),
+    });
+    expect(invitations[0].providerCredentialHash).not.toBe(result.credential);
+    await expect(
+      service.authenticateCredential(
+        result.pairingId,
+        'provider',
+        result.credential,
+      ),
+    ).resolves.toMatchObject({ status: 'pending', role: 'provider' });
+    await expect(
+      service.authenticateCredential(
+        result.pairingId,
+        'provider',
+        'wrong-credential',
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('approves an invitation and authenticates both role-bound credentials', async () => {
+    const provider = await service.createInvitation('pairing-123456789');
+    const controller = await service.approveInvitation(
+      provider.pairingId,
+      'WALLET',
+      'credential-id',
+    );
+
+    expect(controller).toMatchObject({
+      version: 2,
+      pairingId: provider.pairingId,
+      role: 'controller',
+      credential: expect.any(String),
+    });
+    await expect(
+      service.authenticateCredential(
+        provider.pairingId,
+        'provider',
+        provider.credential,
+      ),
+    ).resolves.toMatchObject({ status: 'active', wallet: 'WALLET' });
+    await expect(
+      service.authenticateCredential(
+        controller.pairingId,
+        'controller',
+        controller.credential,
+      ),
+    ).resolves.toMatchObject({ status: 'active', wallet: 'WALLET' });
+    await expect(
+      service.authenticateCredential(
+        controller.pairingId,
+        'provider',
+        controller.credential,
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('allows a verified controller ceremony to recover after an approval response is lost', async () => {
+    const provider = await service.createInvitation('pairing-123456789');
+    await service.approveInvitation(
+      provider.pairingId,
+      'WALLET',
+      'credential-id',
+    );
+
+    await expect(
+      service.bindInvitation(provider.pairingId),
+    ).resolves.toMatchObject({ pairingId: provider.pairingId });
+    await expect(
+      service.approveInvitation(provider.pairingId, 'WALLET', 'credential-id'),
+    ).resolves.toMatchObject({
+      version: 2,
+      pairingId: provider.pairingId,
+      role: 'controller',
+      credential: expect.any(String),
+    });
+  });
+
+  it('never allows an existing pairing to be rebound to a different wallet', async () => {
+    const invitation = await service.createInvitation('pairing-123456789');
+    await service.approveInvitation(
+      invitation.pairingId,
+      'FIRST_WALLET',
+      'credential-id',
+    );
+    await expect(
+      service.approveInvitation(
+        invitation.pairingId,
+        'SECOND_WALLET',
+        'credential-id',
+      ),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('revokes an active pairing for both roles and rejects later authentication', async () => {
+    const provider = await service.createInvitation('pairing-123456789');
+    await service.approveInvitation(
+      provider.pairingId,
+      'WALLET',
+      'credential-id',
+    );
+    await expect(
+      service.revoke(provider.pairingId, 'provider', provider.credential),
+    ).resolves.toEqual({
+      version: 2,
+      pairingId: provider.pairingId,
+      status: 'revoked',
+    });
+    await expect(
+      service.authenticateCredential(
+        provider.pairingId,
+        'provider',
+        provider.credential,
+      ),
+    ).rejects.toThrow('Pairing has been revoked');
+    await expect(
+      service.authenticateCredential(
+        provider.pairingId,
+        'provider',
+        provider.credential,
+        true,
+      ),
+    ).resolves.toMatchObject({ status: 'revoked' });
+  });
+
+  it('keeps an authenticated tombstone so pending revocation is idempotent', async () => {
+    const provider = await service.createInvitation('pairing-123456789');
+
+    await expect(
+      service.revoke(provider.pairingId, 'provider', provider.credential),
+    ).resolves.toEqual({
+      version: 2,
+      pairingId: provider.pairingId,
+      status: 'revoked',
+    });
+    expect(invitations).toHaveLength(1);
+    expect(invitations[0]).toMatchObject({
+      pairingId: provider.pairingId,
+      status: 'revoked',
+      revokedAt: expect.any(Date),
+      providerCredentialHash: expect.any(String),
+    });
+    expect(invitations[0].expiresAt).toBeUndefined();
+
+    // A lost DELETE response can be retried with the original secret.
+    await expect(
+      service.revoke(provider.pairingId, 'provider', provider.credential),
+    ).resolves.toMatchObject({ status: 'revoked' });
+    await expect(
+      service.authenticateCredential(
+        provider.pairingId,
+        'provider',
+        provider.credential,
+        true,
+      ),
+    ).resolves.toMatchObject({ status: 'revoked' });
+  });
+
+  it('does not authenticate arbitrary credentials against a pending-revocation tombstone', async () => {
+    const provider = await service.createInvitation('pairing-123456789');
+    await service.revoke(provider.pairingId, 'provider', provider.credential);
+
+    await expect(
+      service.revoke(provider.pairingId, 'provider', 'wrong-credential'),
+    ).rejects.toMatchObject({ code: 'PAIRING_UNAUTHORIZED' });
+    await expect(
+      service.authenticateCredential(
+        provider.pairingId,
+        'provider',
+        provider.credential,
+      ),
+    ).rejects.toMatchObject({ code: 'PAIRING_REVOKED' });
+  });
+
+  it('never reuses or approves a revoked invitation id', async () => {
+    const provider = await service.createInvitation('pairing-123456789');
+    await service.revoke(provider.pairingId, 'provider', provider.credential);
+
+    await expect(service.bindInvitation(provider.pairingId)).rejects.toThrow(
+      'Pairing invitation not found or expired',
+    );
+    await expect(
+      service.approveInvitation(provider.pairingId, 'WALLET', 'credential-id'),
+    ).rejects.toThrow('Pairing invitation not found or expired');
+    await expect(service.createInvitation(provider.pairingId)).rejects.toThrow(
+      'Pairing id has been revoked',
+    );
+  });
+
+  it('classifies an invitation-to-pairing hand-off as transient', async () => {
+    const provider = await service.createInvitation('pairing-123456789');
+    invitations[0].status = 'consumed';
+
+    const authentication = service.authenticateCredential(
+      provider.pairingId,
+      'provider',
+      provider.credential,
+    );
+    await expect(authentication).rejects.toThrow(
+      'Pairing approval is still being finalized',
+    );
+    await expect(authentication).rejects.not.toBeInstanceOf(
+      PairingAuthorizationError,
+    );
+    await expect(service.createInvitation(provider.pairingId)).rejects.toThrow(
+      'Pairing id is already in use',
+    );
+  });
+
+  it('supports legacy invitations without a status field', async () => {
+    const provider = await service.createInvitation('pairing-123456789');
+    delete invitations[0].status;
+
+    await expect(
+      service.bindInvitation(provider.pairingId),
+    ).resolves.toMatchObject({ pairingId: provider.pairingId });
+    await expect(
+      service.revoke(provider.pairingId, 'provider', provider.credential),
+    ).resolves.toMatchObject({ status: 'revoked' });
+    expect(invitations[0]).toMatchObject({
+      status: 'revoked',
+      revokedAt: expect.any(Date),
+    });
+    expect(invitations[0].expiresAt).toBeUndefined();
+  });
+
+  it('does not mistake a consumed invitation with stale pending status for pending', async () => {
+    const provider = await service.createInvitation('pairing-123456789');
+    invitations[0].consumedAt = new Date();
+
+    await expect(service.bindInvitation(provider.pairingId)).rejects.toThrow(
+      'Pairing invitation not found or expired',
+    );
+    await expect(service.createInvitation(provider.pairingId)).rejects.toThrow(
+      'Pairing id is already in use',
+    );
+  });
+});

--- a/src/pairings/pairing.service.ts
+++ b/src/pairings/pairing.service.ts
@@ -1,0 +1,505 @@
+import * as crypto from 'node:crypto';
+import {
+  ConflictException,
+  GoneException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import {
+  PairingInvitation,
+  PairingInvitationDocument,
+} from './pairing-invitation.schema.js';
+import {
+  Pairing,
+  PairingDocument,
+  PairingRole,
+  PairingStatus,
+} from './pairing.schema.js';
+
+export type PairingCredential = {
+  version: 2;
+  pairingId: string;
+  role: PairingRole;
+  credential: string;
+};
+
+export type PairingInvitationResult = PairingCredential & {
+  role: 'provider';
+  expiresAt: string;
+};
+
+export type PairingApprovalResult = PairingCredential & {
+  role: 'controller';
+};
+
+export type PairingAuthentication = {
+  version: 2;
+  pairingId: string;
+  role: PairingRole;
+  status: PairingStatus | 'pending';
+  wallet?: string;
+};
+
+export type PairingAuthorizationErrorCode =
+  | 'PAIRING_UNAUTHORIZED'
+  | 'PAIRING_REVOKED';
+
+/** A terminal pairing-auth failure that signaling clients must not retry. */
+export class PairingAuthorizationError extends UnauthorizedException {
+  constructor(
+    readonly code: PairingAuthorizationErrorCode,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+@Injectable()
+export class PairingService {
+  private readonly credentialSecret: string;
+  private readonly invitationTtlSeconds: number;
+
+  constructor(
+    @InjectModel(PairingInvitation.name)
+    private readonly invitationModel: Model<PairingInvitation>,
+    @InjectModel(Pairing.name)
+    private readonly pairingModel: Model<Pairing>,
+    private readonly configService: ConfigService,
+  ) {
+    this.credentialSecret =
+      this.configService.get<string>('pairing.credentialSecret') ||
+      this.configService.get<string>('session.secret') ||
+      'secret';
+    this.invitationTtlSeconds =
+      this.configService.get<number>('pairing.invitationTtlSeconds') || 900;
+  }
+
+  async createInvitation(requestId?: string): Promise<PairingInvitationResult> {
+    const pairingId = requestId?.trim() || crypto.randomUUID();
+    if (!this.isValidPublicId(pairingId)) {
+      throw new ConflictException('Invalid pairing id');
+    }
+
+    const existingPairing = await this.pairingModel
+      .findOne({ pairingId })
+      .exec();
+    if (existingPairing) {
+      throw new ConflictException('Pairing id is already in use');
+    }
+
+    const now = new Date();
+    const existingInvitation = await this.invitationModel
+      .findOne({ pairingId })
+      .exec();
+    const existingStatus = this.invitationStatus(existingInvitation);
+    if (existingStatus === 'revoked') {
+      throw new ConflictException('Pairing id has been revoked');
+    }
+    if (existingStatus === 'consumed') {
+      throw new ConflictException('Pairing id is already in use');
+    }
+    if (
+      existingInvitation &&
+      existingStatus === 'pending' &&
+      existingInvitation.expiresAt &&
+      existingInvitation.expiresAt > now
+    ) {
+      throw new ConflictException('Pairing invitation already exists');
+    }
+    if (existingInvitation) {
+      await this.invitationModel.deleteOne({ pairingId }).exec();
+    }
+
+    const credential = this.generateCredential();
+    const expiresAt = new Date(
+      now.getTime() + this.invitationTtlSeconds * 1000,
+    );
+    const invitation = new this.invitationModel({
+      pairingId,
+      requestId: pairingId,
+      providerCredentialHash: this.hashCredential(credential),
+      expiresAt,
+      status: 'pending',
+    });
+
+    try {
+      await invitation.save();
+    } catch (error) {
+      if ((error as { code?: number })?.code === 11000) {
+        throw new ConflictException('Pairing id is already in use');
+      }
+      throw error;
+    }
+
+    return {
+      version: 2,
+      pairingId,
+      role: 'provider',
+      credential,
+      expiresAt: expiresAt.toISOString(),
+    };
+  }
+
+  async bindInvitation(
+    requestId: string,
+  ): Promise<Pick<PairingInvitationDocument, 'pairingId'>> {
+    const invitation = await this.invitationModel
+      .findOne({
+        $and: [
+          { $or: [{ pairingId: requestId }, { requestId }] },
+          this.pendingInvitationStateFilter(),
+        ],
+        expiresAt: { $gt: new Date() },
+      })
+      .exec();
+    if (invitation) return invitation as PairingInvitationDocument;
+
+    // Approval is intentionally retryable. The first WebAuthn response may
+    // commit the pairing while its HTTP response is lost; allowing the same
+    // public id to bind again lets a subsequent, independently verified
+    // ceremony return a fresh controller credential. `approveInvitation()`
+    // still requires the proven wallet to match the stored pairing and refuses
+    // revoked records, so this does not let a public pairing id rebind an agent.
+    const activePairing = await this.pairingModel
+      .findOne({ pairingId: requestId, status: 'active' })
+      .exec();
+    if (activePairing) return { pairingId: activePairing.pairingId };
+
+    throw new NotFoundException('Pairing invitation not found or expired');
+  }
+
+  async approveInvitation(
+    requestId: string,
+    wallet: string,
+    approvingCredentialId: string,
+  ): Promise<PairingApprovalResult> {
+    const existing = await this.pairingModel
+      .findOne({ pairingId: requestId })
+      .exec();
+    if (existing) {
+      return this.refreshControllerCredential(
+        existing,
+        wallet,
+        approvingCredentialId,
+      );
+    }
+
+    const now = new Date();
+    const invitation = await this.invitationModel
+      .findOneAndUpdate(
+        {
+          $and: [
+            { $or: [{ pairingId: requestId }, { requestId }] },
+            this.pendingInvitationStateFilter(),
+          ],
+          expiresAt: { $gt: now },
+        },
+        { status: 'consumed', consumedAt: now },
+        { new: true },
+      )
+      .exec();
+    if (!invitation) {
+      const racedPairing = await this.pairingModel
+        .findOne({ pairingId: requestId })
+        .exec();
+      if (racedPairing) {
+        return this.refreshControllerCredential(
+          racedPairing,
+          wallet,
+          approvingCredentialId,
+        );
+      }
+      throw new NotFoundException('Pairing invitation not found or expired');
+    }
+
+    const credential = this.generateCredential();
+    const pairing = new this.pairingModel({
+      pairingId: invitation.pairingId,
+      wallet,
+      providerCredentialHash: invitation.providerCredentialHash,
+      controllerCredentialHash: this.hashCredential(credential),
+      status: 'active',
+      approvingCredentialId,
+    });
+
+    try {
+      await pairing.save();
+    } catch (error) {
+      if ((error as { code?: number })?.code !== 11000) throw error;
+      const racedPairing = await this.pairingModel
+        .findOne({ pairingId: invitation.pairingId })
+        .exec();
+      if (!racedPairing) throw error;
+      return this.refreshControllerCredential(
+        racedPairing,
+        wallet,
+        approvingCredentialId,
+      );
+    }
+
+    return {
+      version: 2,
+      pairingId: invitation.pairingId,
+      role: 'controller',
+      credential,
+    };
+  }
+
+  async findActivePairing(pairingId: string): Promise<PairingDocument | null> {
+    return this.pairingModel
+      .findOne({ pairingId, status: 'active' })
+      .exec() as Promise<PairingDocument | null>;
+  }
+
+  async authenticateCredential(
+    pairingId: string,
+    role: PairingRole,
+    credential: string,
+    allowRevoked = false,
+  ): Promise<PairingAuthentication> {
+    if (
+      !pairingId ||
+      !credential ||
+      (role !== 'provider' && role !== 'controller')
+    ) {
+      throw new PairingAuthorizationError(
+        'PAIRING_UNAUTHORIZED',
+        'Invalid pairing credentials',
+      );
+    }
+
+    const pairing = await this.pairingModel.findOne({ pairingId }).exec();
+    if (pairing) {
+      const expectedHash =
+        role === 'provider'
+          ? pairing.providerCredentialHash
+          : pairing.controllerCredentialHash;
+      if (!this.credentialMatches(credential, expectedHash)) {
+        throw new PairingAuthorizationError(
+          'PAIRING_UNAUTHORIZED',
+          'Invalid pairing credentials',
+        );
+      }
+      if (pairing.status === 'revoked' && !allowRevoked) {
+        throw new PairingAuthorizationError(
+          'PAIRING_REVOKED',
+          'Pairing has been revoked',
+        );
+      }
+      return {
+        version: 2,
+        pairingId,
+        role,
+        status: pairing.status,
+        wallet: pairing.wallet,
+      };
+    }
+
+    if (role === 'provider') {
+      const invitation = await this.invitationModel
+        .findOne({ pairingId })
+        .exec();
+      if (
+        invitation &&
+        this.credentialMatches(credential, invitation.providerCredentialHash)
+      ) {
+        const invitationStatus = this.invitationStatus(invitation);
+        if (invitationStatus === 'revoked') {
+          if (!allowRevoked) {
+            throw new PairingAuthorizationError(
+              'PAIRING_REVOKED',
+              'Pairing has been revoked',
+            );
+          }
+          return { version: 2, pairingId, role, status: 'revoked' };
+        }
+        if (
+          invitationStatus === 'pending' &&
+          invitation.expiresAt &&
+          invitation.expiresAt > new Date()
+        ) {
+          return { version: 2, pairingId, role, status: 'pending' };
+        }
+        if (invitationStatus === 'consumed') {
+          // The invitation is claimed before its durable pairing is inserted.
+          // Treat that small hand-off window as transient, never as a terminal
+          // credential failure that would make a client discard the pairing.
+          throw new Error('Pairing approval is still being finalized');
+        }
+      }
+    }
+
+    throw new PairingAuthorizationError(
+      'PAIRING_UNAUTHORIZED',
+      'Invalid pairing credentials',
+    );
+  }
+
+  async revoke(
+    pairingId: string,
+    role: PairingRole,
+    credential: string,
+  ): Promise<{ version: 2; pairingId: string; status: 'revoked' }> {
+    const authentication = await this.authenticateCredential(
+      pairingId,
+      role,
+      credential,
+      true,
+    );
+    if (authentication.status === 'pending') {
+      const revokedAt = new Date();
+      const invitation = await this.invitationModel
+        .findOneAndUpdate(
+          {
+            pairingId,
+            providerCredentialHash: this.hashCredential(credential),
+            ...this.pendingInvitationStateFilter(),
+          },
+          {
+            $set: { status: 'revoked', revokedAt },
+            // Preserve the deployed expiresAt TTL index. MongoDB ignores a
+            // missing TTL field, so the credential-authenticated tombstone is
+            // permanent without an index migration or an expiry race.
+            $unset: { expiresAt: 1 },
+          },
+          { new: true },
+        )
+        .exec();
+      if (!invitation) {
+        // Approval or another revoke won the compare-and-set. Re-authenticate
+        // so we either revoke the active record, accept its tombstone, or ask
+        // the caller to retry while approval finishes.
+        const raced = await this.authenticateCredential(
+          pairingId,
+          role,
+          credential,
+          true,
+        );
+        if (raced.status === 'active') {
+          await this.revokeActivePairing(pairingId);
+        } else if (raced.status !== 'revoked') {
+          throw new Error('Pairing state changed while it was being revoked');
+        }
+      }
+    } else if (authentication.status !== 'revoked') {
+      await this.revokeActivePairing(pairingId);
+    }
+    return { version: 2, pairingId, status: 'revoked' };
+  }
+
+  private async revokeActivePairing(pairingId: string): Promise<void> {
+    const pairing = await this.pairingModel
+      .findOneAndUpdate(
+        { pairingId, status: 'active' },
+        { status: 'revoked', revokedAt: new Date() },
+        { new: true },
+      )
+      .exec();
+    if (pairing) return;
+
+    const current = await this.pairingModel.findOne({ pairingId }).exec();
+    if (current?.status === 'revoked') return;
+    throw new Error('Pairing state changed while it was being revoked');
+  }
+
+  private async refreshControllerCredential(
+    pairing: Pairing,
+    wallet: string,
+    approvingCredentialId: string,
+  ): Promise<PairingApprovalResult> {
+    if (pairing.wallet !== wallet) {
+      throw new ConflictException('Pairing is already bound to another wallet');
+    }
+    if (pairing.status === 'revoked') {
+      throw new GoneException('Pairing has been revoked');
+    }
+    const credential = this.generateCredential();
+    const updated = await this.pairingModel
+      .findOneAndUpdate(
+        { pairingId: pairing.pairingId, wallet, status: 'active' },
+        {
+          controllerCredentialHash: this.hashCredential(credential),
+          approvingCredentialId,
+        },
+        { new: true },
+      )
+      .exec();
+    if (!updated) {
+      const current = await this.pairingModel
+        .findOne({ pairingId: pairing.pairingId })
+        .exec();
+      if (current?.status === 'revoked') {
+        throw new GoneException('Pairing has been revoked');
+      }
+      throw new ConflictException('Pairing could not be refreshed');
+    }
+    return {
+      version: 2,
+      pairingId: pairing.pairingId,
+      role: 'controller',
+      credential,
+    };
+  }
+
+  private generateCredential(): string {
+    return crypto.randomBytes(32).toString('base64url');
+  }
+
+  private pendingInvitationStateFilter(): Record<string, unknown> {
+    return {
+      $or: [
+        {
+          status: 'pending',
+          consumedAt: { $exists: false },
+          revokedAt: { $exists: false },
+        },
+        {
+          status: { $exists: false },
+          consumedAt: { $exists: false },
+          revokedAt: { $exists: false },
+        },
+      ],
+    };
+  }
+
+  private invitationStatus(
+    invitation: Pick<
+      PairingInvitation,
+      'status' | 'consumedAt' | 'revokedAt'
+    > | null,
+  ): 'pending' | 'consumed' | 'revoked' | undefined {
+    if (!invitation) return undefined;
+    if (invitation.revokedAt) return 'revoked';
+    if (invitation.consumedAt) return 'consumed';
+    if (invitation.status) return invitation.status;
+    return 'pending';
+  }
+
+  private hashCredential(credential: string): string {
+    return crypto
+      .createHmac('sha256', this.credentialSecret)
+      .update(credential)
+      .digest('base64url');
+  }
+
+  private credentialMatches(credential: string, expectedHash: string): boolean {
+    const actual = Buffer.from(this.hashCredential(credential));
+    const expected = Buffer.from(expectedHash || '');
+    return (
+      actual.length === expected.length &&
+      crypto.timingSafeEqual(actual, expected)
+    );
+  }
+
+  private isValidPublicId(value: string): boolean {
+    return (
+      value.length >= 16 &&
+      value.length <= 256 &&
+      /^[a-zA-Z0-9_-]+$/.test(value)
+    );
+  }
+}

--- a/src/signals/signals.gateway.spec.ts
+++ b/src/signals/signals.gateway.spec.ts
@@ -11,6 +11,13 @@ import candidateFixture from './__fixtures__/candidate.fixture.json';
 import sdpFixtures from './__fixtures__/sdp.fixtures.json';
 import sessionFixtures from '../__fixtures__/session.fixtures.json';
 import { Session } from 'express-session';
+import {
+  PairingAuthorizationError,
+  PairingService,
+} from '../pairings/pairing.service.js';
+import { mockPairingService } from '../__mocks__/pairing.service.mock.js';
+import { firstValueFrom } from 'rxjs';
+import { WsException } from '@nestjs/websockets';
 
 const clientMock = {
   request: {
@@ -21,6 +28,7 @@ const clientMock = {
   join: jest.fn(),
 } as unknown as Socket;
 let linkEventFn: any;
+let socketMiddleware: any;
 const ioAdapterMock = {
   subClient: {
     on: jest.fn((name: string, fn) => {
@@ -36,7 +44,12 @@ jest.mock('socket.io', () => {
       return {
         emit: jest.fn(),
         in: jest.fn().mockReturnThis(),
+        to: jest.fn().mockReturnThis(),
+        use: jest.fn((fn) => {
+          socketMiddleware = fn;
+        }),
         socketsJoin: jest.fn(),
+        disconnectSockets: jest.fn(),
         sockets: {
           adapter: ioAdapterMock,
         },
@@ -73,6 +86,10 @@ describe('SignalsGateway', () => {
               .mockResolvedValue(sessionFixtures.authorized),
           },
         },
+        {
+          provide: PairingService,
+          useValue: mockPairingService,
+        },
         SignalsGateway,
       ],
     }).compile();
@@ -91,6 +108,140 @@ describe('SignalsGateway', () => {
     gateway.afterInit(gateway.server);
     // @ts-expect-error, testing purposes
     expect(gateway.ioAdapter).toBeInstanceOf(Object);
+  });
+  it('should authenticate a durable pairing during the socket handshake', async () => {
+    gateway.afterInit(gateway.server);
+    const next = jest.fn();
+    const socket = {
+      handshake: {
+        auth: {
+          version: 2,
+          pairingId: 'pairing-123456789',
+          role: 'provider',
+          credential: 'provider-credential',
+        },
+      },
+      data: {},
+    };
+    await socketMiddleware(socket, next);
+    expect(mockPairingService.authenticateCredential).toHaveBeenCalledWith(
+      'pairing-123456789',
+      'provider',
+      'provider-credential',
+    );
+    expect(socket.data).toEqual({
+      liquidPairing: expect.objectContaining({
+        pairingId: 'pairing-123456789',
+        role: 'provider',
+        credential: 'provider-credential',
+      }),
+    });
+    expect(next).toHaveBeenCalledWith();
+  });
+  it.each([
+    [
+      'invalid',
+      new PairingAuthorizationError(
+        'PAIRING_UNAUTHORIZED',
+        'Invalid pairing credentials',
+      ),
+      'PAIRING_UNAUTHORIZED',
+    ],
+    [
+      'revoked',
+      new PairingAuthorizationError(
+        'PAIRING_REVOKED',
+        'Pairing has been revoked',
+      ),
+      'PAIRING_REVOKED',
+    ],
+  ])(
+    'should return a machine-readable %s pairing handshake error',
+    async (_reason, failure, code) => {
+      gateway.afterInit(gateway.server);
+      mockPairingService.authenticateCredential.mockRejectedValueOnce(failure);
+      const next = jest.fn();
+      await socketMiddleware(
+        {
+          handshake: {
+            auth: {
+              version: 2,
+              pairingId: 'pairing-123456789',
+              role: 'provider',
+              credential: 'provider-credential',
+            },
+          },
+          data: {},
+        },
+        next,
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { code } }),
+      );
+    },
+  );
+  it('should leave backend handshake failures transient and un-coded', async () => {
+    gateway.afterInit(gateway.server);
+    const failure = new Error('MongoDB is unavailable');
+    mockPairingService.authenticateCredential.mockRejectedValueOnce(failure);
+    const next = jest.fn();
+    await socketMiddleware(
+      {
+        handshake: {
+          auth: {
+            version: 2,
+            pairingId: 'pairing-123456789',
+            role: 'provider',
+            credential: 'provider-credential',
+          },
+        },
+        data: {},
+      },
+      next,
+    );
+    expect(next).toHaveBeenCalledWith(failure);
+    expect((failure as Error & { data?: unknown }).data).toBeUndefined();
+  });
+  it('should broadcast revocation and disconnect pairing sockets across instances', async () => {
+    gateway.afterInit(gateway.server);
+    await linkEventFn(
+      'auth',
+      JSON.stringify({
+        data: {
+          type: 'pairing:revoked',
+          version: 2,
+          pairingId: 'pairing-123456789',
+          status: 'revoked',
+        },
+      }),
+    );
+    expect(gateway.server.to).toHaveBeenCalledWith('pairing:pairing-123456789');
+    expect(gateway.server.emit).toHaveBeenCalledWith('pairing:revoked', {
+      version: 2,
+      pairingId: 'pairing-123456789',
+      status: 'revoked',
+    });
+    expect(gateway.server.in).toHaveBeenCalledWith('pairing:pairing-123456789');
+    expect(gateway.server.disconnectSockets).toHaveBeenCalledWith(true);
+  });
+  it('should join durable pair and role rooms on every connection', async () => {
+    const join = jest.fn();
+    await gateway.handleConnection({
+      data: {
+        liquidPairing: {
+          version: 2,
+          pairingId: 'pairing-123456789',
+          role: 'controller',
+          credential: 'controller-credential',
+          status: 'active',
+        },
+      },
+      request: {},
+      rooms: new Set(),
+      join,
+    } as unknown as Socket);
+    expect(join).toHaveBeenCalledWith('pairing:pairing-123456789');
+    expect(join).toHaveBeenCalledWith('pairing:pairing-123456789:controller');
   });
   it('should handle a authenticated connection', async () => {
     await gateway.handleConnection(clientMock);
@@ -158,10 +309,199 @@ describe('SignalsGateway', () => {
       },
     });
   });
+  it('should resolve an already-approved durable link immediately from storage', async () => {
+    mockPairingService.findActivePairing.mockResolvedValueOnce({
+      pairingId: 'pairing-123456789',
+      wallet: 'WALLET',
+      approvingCredentialId: 'credential-id',
+    } as any);
+    const join = jest.fn();
+    const client = {
+      data: {
+        liquidPairing: {
+          version: 2,
+          pairingId: 'pairing-123456789',
+          role: 'provider',
+          credential: 'provider-credential',
+          status: 'active',
+        },
+      },
+      request: {},
+      rooms: new Set(),
+      join,
+    } as unknown as Socket;
+    const response = await firstValueFrom(
+      await gateway.link({ requestId: 'pairing-123456789' }, client),
+    );
+    expect(response).toEqual({
+      data: {
+        version: 2,
+        pairingId: 'pairing-123456789',
+        requestId: 'pairing-123456789',
+        wallet: 'WALLET',
+        credId: 'credential-id',
+      },
+    });
+    expect(join).toHaveBeenCalledWith('pairing:pairing-123456789:provider');
+  });
+  it.each([
+    ['PAIRING_UNAUTHORIZED', 'Invalid pairing credentials'],
+    ['PAIRING_REVOKED', 'Pairing has been revoked'],
+  ] as const)(
+    'should emit a structured %s error for terminal link authorization failures',
+    async (code, message) => {
+      mockPairingService.authenticateCredential.mockRejectedValueOnce(
+        new PairingAuthorizationError(code, message),
+      );
+      const client = {
+        data: {
+          liquidPairing: {
+            version: 2,
+            pairingId: 'pairing-123456789',
+            role: 'provider',
+            credential: 'provider-credential',
+            status: 'pending',
+          },
+        },
+        request: {},
+        rooms: new Set(),
+        join: jest.fn(),
+      } as unknown as Socket;
+
+      let failure: unknown;
+      try {
+        await gateway.link({ requestId: 'pairing-123456789' }, client);
+      } catch (error) {
+        failure = error;
+      }
+
+      expect(failure).toBeInstanceOf(WsException);
+      expect((failure as WsException).getError()).toEqual({
+        status: 'error',
+        code,
+        message,
+        error: message,
+        cause: {
+          pattern: 'link',
+          data: { requestId: 'pairing-123456789' },
+        },
+      });
+    },
+  );
+  it('should classify a role or request mismatch as unauthorized', async () => {
+    const client = {
+      data: {
+        liquidPairing: {
+          version: 2,
+          pairingId: 'pairing-123456789',
+          role: 'controller',
+          credential: 'controller-credential',
+          status: 'active',
+        },
+      },
+      request: {},
+      rooms: new Set(),
+      join: jest.fn(),
+    } as unknown as Socket;
+
+    let failure: unknown;
+    try {
+      await gateway.link({ requestId: 'pairing-123456789' }, client);
+    } catch (error) {
+      failure = error;
+    }
+    expect((failure as WsException).getError()).toMatchObject({
+      code: 'PAIRING_UNAUTHORIZED',
+      cause: { pattern: 'link' },
+    });
+  });
+  it('should leave link database failures generic and retryable', async () => {
+    const backendFailure = new Error('MongoDB is unavailable');
+    mockPairingService.authenticateCredential.mockRejectedValueOnce(
+      backendFailure,
+    );
+    const client = {
+      data: {
+        liquidPairing: {
+          version: 2,
+          pairingId: 'pairing-123456789',
+          role: 'provider',
+          credential: 'provider-credential',
+          status: 'pending',
+        },
+      },
+      request: {},
+      rooms: new Set(),
+      join: jest.fn(),
+    } as unknown as Socket;
+
+    await expect(
+      gateway.link({ requestId: 'pairing-123456789' }, client),
+    ).rejects.toBe(backendFailure);
+    expect((backendFailure as Error & { code?: unknown }).code).toBeUndefined();
+  });
+  it('should recover if approval lands while the durable link listener is attaching', async () => {
+    mockPairingService.findActivePairing
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        pairingId: 'pairing-123456789',
+        wallet: 'WALLET',
+        approvingCredentialId: 'credential-id',
+      } as any);
+    const client = {
+      data: {
+        liquidPairing: {
+          version: 2,
+          pairingId: 'pairing-123456789',
+          role: 'provider',
+          credential: 'provider-credential',
+          status: 'pending',
+        },
+      },
+      request: {},
+      rooms: new Set(),
+      join: jest.fn(),
+    } as unknown as Socket;
+    const response = await firstValueFrom(
+      await gateway.link({ requestId: 'pairing-123456789' }, client),
+    );
+    expect(response.data).toMatchObject({
+      version: 2,
+      pairingId: 'pairing-123456789',
+      wallet: 'WALLET',
+    });
+    expect(ioAdapterMock.subClient.off).toHaveBeenCalledWith(
+      'message',
+      expect.any(Function),
+    );
+  });
   it('should signal a offer-description', async () => {
     await gateway.onOfferDescription(sdpFixtures.call, clientMock);
     expect(gateway.server.in).toHaveBeenCalledWith(
       (clientMock.request as any).session.wallet,
+    );
+    expect(gateway.server.emit).toHaveBeenCalledWith(
+      'offer-description',
+      sdpFixtures.call,
+    );
+  });
+  it('should route durable pairing signals only to the opposite role', async () => {
+    const pairingClient = {
+      data: {
+        liquidPairing: {
+          version: 2,
+          pairingId: 'pairing-123456789',
+          role: 'provider',
+          credential: 'provider-credential',
+          status: 'active',
+        },
+      },
+      request: {},
+      rooms: new Set(),
+    } as unknown as Socket;
+    await gateway.onOfferDescription(sdpFixtures.call, pairingClient);
+    expect(gateway.server.to).toHaveBeenCalledWith(
+      'pairing:pairing-123456789:controller',
     );
     expect(gateway.server.emit).toHaveBeenCalledWith(
       'offer-description',

--- a/src/signals/signals.gateway.ts
+++ b/src/signals/signals.gateway.ts
@@ -7,31 +7,52 @@ import {
   SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,
+  WsException,
 } from '@nestjs/websockets';
 import { Logger } from '@nestjs/common';
 import type { Server, Socket } from 'socket.io';
 import { Session as SessionType } from 'express-session';
-import { Observable, Subscriber } from 'rxjs';
+import { Observable, Subscriber, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { RedisIoAdapter } from '../adapters/redis-io.adapter.js';
 import { AuthService } from '../auth/auth.service.js';
 import { Session } from '../auth/session.schema.js';
+import { PairingRole } from '../pairings/pairing.schema.js';
+import {
+  PairingAuthorizationError,
+  PairingService,
+} from '../pairings/pairing.service.js';
+
+type PairingSocketContext = {
+  version: 2;
+  pairingId: string;
+  role: PairingRole;
+  credential: string;
+  status: 'pending' | 'active';
+  wallet?: string;
+};
+
+export function pairingRoom(pairingId: string): string {
+  return `pairing:${pairingId}`;
+}
+
+export function pairingRoleRoom(pairingId: string, role: PairingRole): string {
+  return `${pairingRoom(pairingId)}:${role}`;
+}
+
 export async function reloadSession(session: SessionType) {
   return new Promise((resolve, reject) => {
     session.reload((err) => {
       if (err) {
         reject(err);
+        return;
       }
       resolve(session);
     });
   });
 }
 
-@WebSocketGateway({
-  cors: {
-    origin: '*',
-  },
-})
+@WebSocketGateway()
 export class SignalsGateway
   implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect
 {
@@ -39,57 +60,121 @@ export class SignalsGateway
   server: Server;
   private ioAdapter: RedisIoAdapter;
   private readonly logger = new Logger(SignalsGateway.name);
-  constructor(private authService: AuthService) {}
-  /**
-   * Initialize the Gateway
-   *
-   * Pulls the RedisIoAdapter instance from the server
-   *
-   * @param server
-   */
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly pairingService: PairingService,
+  ) {}
+
   afterInit(server: Server) {
     this.ioAdapter = server.sockets.adapter as unknown as RedisIoAdapter;
+    server.use(async (socket, next) => {
+      const auth = socket.handshake?.auth as Record<string, any> | undefined;
+      if (Number(auth?.version) !== 2) {
+        next();
+        return;
+      }
+      try {
+        const result = await this.pairingService.authenticateCredential(
+          auth.pairingId,
+          auth.role,
+          auth.credential,
+        );
+        socket.data.liquidPairing = {
+          ...result,
+          status: result.status as 'pending' | 'active',
+          credential: auth.credential,
+        } satisfies PairingSocketContext;
+        next();
+      } catch (error) {
+        if (!(error instanceof PairingAuthorizationError)) {
+          next(
+            error instanceof Error
+              ? error
+              : new Error('Pairing authentication temporarily unavailable'),
+          );
+          return;
+        }
+        const handshakeError = new Error(error.message) as Error & {
+          data?: { code: string };
+        };
+        handshakeError.data = { code: error.code };
+        next(handshakeError);
+      }
+    });
+
     this.ioAdapter.subClient.subscribe('auth');
     this.ioAdapter.subClient.on('message', (channel, message) => {
-      if (channel === 'auth') {
-        try {
-          const parsed = JSON.parse(message);
-          const data = parsed.data || parsed;
-          if (data.sessionId && data.wallet) {
-            this.logger.debug(
-              `(*) Global Auth Event: Joining Sockets for Session ${data.sessionId} to Room ${data.wallet}`,
-            );
-            server.in(data.sessionId).socketsJoin(data.wallet);
-          }
-        } catch (e) {
-          this.logger.error('Failed to handle global auth message', e);
+      if (channel !== 'auth') return;
+      try {
+        const parsed = JSON.parse(message);
+        const data = parsed.data || parsed;
+        if (data.type === 'pairing:revoked' && data.pairingId) {
+          const room = pairingRoom(data.pairingId);
+          const revocation = {
+            version: 2,
+            pairingId: data.pairingId,
+            status: 'revoked',
+          };
+          server.to(room).emit('pairing:revoked', revocation);
+          server.in(room).disconnectSockets(true);
+          return;
         }
+        if (data.sessionId && data.wallet) {
+          this.logger.debug(
+            `(*) Global Auth Event: Joining Sockets for Session ${data.sessionId} to Room ${data.wallet}`,
+          );
+          server.in(data.sessionId).socketsJoin(data.wallet);
+        }
+        if (data.pairingId && data.wallet) {
+          server
+            .to(pairingRoleRoom(data.pairingId, 'provider'))
+            .emit('pairing-approved', {
+              version: 2,
+              pairingId: data.pairingId,
+              wallet: data.wallet,
+              credId: data.credId,
+            });
+        }
+      } catch (error) {
+        this.logger.error('Failed to handle global auth message', error);
       }
     });
   }
 
-  /**
-   * Handle Connection
-   *
-   * Automatically join the client to the public key's room
-   *
-   * @param socket
-   */
   async handleConnection(socket: Socket) {
+    const pairing = this.pairingContext(socket);
+    if (pairing) {
+      await Promise.all([
+        socket.join(pairingRoom(pairing.pairingId)),
+        socket.join(pairingRoleRoom(pairing.pairingId, pairing.role)),
+      ]);
+    }
+
     const request = socket.request as Record<string, any>;
-    await reloadSession(request.session);
-    const session = request.session as Record<string, any>;
+    let session = request.session as Record<string, any> | undefined;
+    if (session && typeof session.reload === 'function') {
+      try {
+        await reloadSession(session as SessionType);
+        session = request.session as Record<string, any>;
+      } catch (error) {
+        this.logger.warn(
+          `Unable to reload legacy session ${request.sessionID || 'unknown'}: ${(error as Error).message}`,
+        );
+        session = undefined;
+      }
+    }
 
     this.logger.debug(
-      `(*) Client Connected with Session: ${request.sessionID}${
-        session.wallet ? ` and PublicKey: ${session.wallet}` : ''
-      }`,
+      `(*) Client Connected with Session: ${request.sessionID || 'none'}${
+        session?.wallet ? ` and PublicKey: ${session.wallet}` : ''
+      }${pairing ? ` and Pairing: ${pairing.pairingId}/${pairing.role}` : ''}`,
     );
     if (typeof request.sessionID === 'string') {
       await socket.join(request.sessionID);
     }
     if (
-      typeof session.wallet === 'string' &&
+      typeof session?.wallet === 'string' &&
       !socket.rooms.has(session.wallet)
     ) {
       this.logger.debug(
@@ -101,84 +186,204 @@ export class SignalsGateway
 
   handleDisconnect(socket: Socket) {
     const request = socket.request as Record<string, any>;
+    const pairing = this.pairingContext(socket);
     this.logger.debug(
-      `(*) Client Disconnected with Session: ${request.sessionID}`,
+      `(*) Client Disconnected with Session: ${request.sessionID || 'none'}${
+        pairing ? ` and Pairing: ${pairing.pairingId}/${pairing.role}` : ''
+      }`,
     );
   }
 
-  /**
-   * On Link Connection, wait for the wallet to connect
-   * @param client
-   * @param body
-   */
   @SubscribeMessage('link')
   async link(
     @MessageBody() body: { requestId: string },
     @ConnectedSocket() client: Socket,
-  ): Promise<Observable<{ data: { requestId: string; wallet: string } }>> {
+  ): Promise<Observable<{ data: Record<string, any> }>> {
     const request = client.request as Record<string, any>;
+    const pairingContext = this.pairingContext(client);
     this.logger.debug(
-      `(link): link for Session: ${request.sessionID} with RequestId: ${body.requestId}`,
+      `(link): link for Session: ${request.sessionID || 'none'} with RequestId: ${body.requestId}`,
     );
-    // Find the stored session
-    const session = await this.authService.findSession(request.sessionID);
-    if (session) {
-      await this.ioAdapter.subClient.subscribe('auth');
-      const handleObserver = (observer: Subscriber<any>) => {
-        const handleAuthMessage = async (
-          channel: string,
-          eventMessage: string,
-        ) => {
-          if (channel !== 'auth') {
-            return;
-          }
-          try {
-            const parsed = JSON.parse(eventMessage);
-            const data = parsed.data || parsed;
-            if (data && body.requestId === data.requestId) {
+
+    if (pairingContext) {
+      if (
+        pairingContext.role !== 'provider' ||
+        pairingContext.pairingId !== body.requestId
+      ) {
+        throw this.linkAuthorizationException(
+          new PairingAuthorizationError(
+            'PAIRING_UNAUTHORIZED',
+            'Pairing does not match link request',
+          ),
+          body,
+        );
+      }
+      try {
+        await this.pairingService.authenticateCredential(
+          pairingContext.pairingId,
+          pairingContext.role,
+          pairingContext.credential,
+        );
+      } catch (error) {
+        if (error instanceof PairingAuthorizationError) {
+          throw this.linkAuthorizationException(error, body);
+        }
+        throw error;
+      }
+      const resolved = await this.pairingService.findActivePairing(
+        pairingContext.pairingId,
+      );
+      if (resolved) {
+        await client.join(
+          pairingRoleRoom(pairingContext.pairingId, pairingContext.role),
+        );
+        return of({
+          data: {
+            version: 2,
+            pairingId: resolved.pairingId,
+            requestId: resolved.pairingId,
+            wallet: resolved.wallet,
+            credId: resolved.approvingCredentialId,
+          },
+        });
+      }
+    }
+
+    const storedSession = request.sessionID
+      ? await this.authService.findSession(request.sessionID)
+      : null;
+    if (!pairingContext && !storedSession) {
+      throw new WsException('Signaling session not found');
+    }
+
+    await this.ioAdapter.subClient.subscribe('auth');
+    const handleObserver = (observer: Subscriber<any>) => {
+      let settled = false;
+      const settle = async (
+        data: Record<string, any>,
+        prepare?: () => unknown | Promise<unknown>,
+      ) => {
+        if (settled) return;
+        settled = true;
+        try {
+          if (prepare) await prepare();
+          this.ioAdapter.subClient.off('message', handleAuthMessage);
+          observer.next(data);
+          observer.complete();
+        } catch (error) {
+          this.logger.error('Failed to complete link', error);
+          this.ioAdapter.subClient.off('message', handleAuthMessage);
+          observer.error(error);
+        }
+      };
+      const fail = (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        this.logger.error('Failed to handle auth message in link', error);
+        this.ioAdapter.subClient.off('message', handleAuthMessage);
+        observer.error(error);
+      };
+      const handleAuthMessage = async (
+        channel: string,
+        eventMessage: string,
+      ) => {
+        if (channel !== 'auth') return;
+        try {
+          const parsed = JSON.parse(eventMessage);
+          const data = parsed.data || parsed;
+          if (!data || body.requestId !== data.requestId) return;
+
+          if (pairingContext) {
+            const resolved = await this.pairingService.findActivePairing(
+              pairingContext.pairingId,
+            );
+            if (!resolved || resolved.wallet !== data.wallet) return;
+            await settle(
+              {
+                ...data,
+                version: 2,
+                pairingId: resolved.pairingId,
+              },
+              () =>
+                client.join(
+                  pairingRoleRoom(
+                    pairingContext.pairingId,
+                    pairingContext.role,
+                  ),
+                ),
+            );
+          } else {
+            await settle(data, async () => {
               this.logger.debug(
                 `(*) Linking Wallet: ${data.wallet} to Session: ${request.sessionID}`,
               );
-              await this.authService.updateSessionWallet(session, data.wallet);
-              await reloadSession(request.session);
-              this.logger.debug(
-                `(*) Joining Room: ${data.wallet} with Session: ${request.sessionID}`,
+              await this.authService.updateSessionWallet(
+                storedSession,
+                data.wallet,
               );
+              if (
+                request.session &&
+                typeof request.session.reload === 'function'
+              ) {
+                await reloadSession(request.session);
+              }
               await client.join(data.wallet);
-              this.ioAdapter.subClient.off('message', handleAuthMessage);
-              observer.next(data);
-              observer.complete();
-            }
-          } catch (e) {
-            this.logger.error('Failed to handle auth message in link', e);
-            this.ioAdapter.subClient.off('message', handleAuthMessage);
+            });
           }
-        };
-
-        this.ioAdapter.subClient.on('message', handleAuthMessage);
-
-        return () => {
-          this.ioAdapter.subClient.off('message', handleAuthMessage);
-        };
+        } catch (error) {
+          fail(error);
+        }
       };
-      if (process.env.NODE_ENV === 'test') {
-        globalThis.handleObserver = handleObserver;
+
+      this.ioAdapter.subClient.on('message', handleAuthMessage);
+      if (pairingContext) {
+        // Close the small race where approval lands after the initial database
+        // lookup but before this Redis listener is attached.
+        void this.pairingService
+          .findActivePairing(pairingContext.pairingId)
+          .then(async (resolved) => {
+            if (!resolved) return;
+            await settle(
+              {
+                version: 2,
+                pairingId: resolved.pairingId,
+                requestId: resolved.pairingId,
+                wallet: resolved.wallet,
+                credId: resolved.approvingCredentialId,
+              },
+              () =>
+                client.join(
+                  pairingRoleRoom(
+                    pairingContext.pairingId,
+                    pairingContext.role,
+                  ),
+                ),
+            );
+          })
+          .catch(fail);
       }
-      // Handle messages
-      const obs$: Observable<any> = new Observable(handleObserver);
-      const handleObserverMap = (_obs$: any) => ({
-        data: {
-          credId: _obs$.credId,
-          requestId: _obs$.requestId,
-          wallet: _obs$.wallet,
-        },
-      });
-      if (process.env.NODE_ENV === 'test') {
-        globalThis.handleObserverMap = handleObserverMap;
-      }
-      return obs$.pipe(map(handleObserverMap));
+      return () => {
+        settled = true;
+        this.ioAdapter.subClient.off('message', handleAuthMessage);
+      };
+    };
+    if (process.env.NODE_ENV === 'test') {
+      globalThis.handleObserver = handleObserver;
     }
+    const obs$: Observable<any> = new Observable(handleObserver);
+    const handleObserverMap = (_obs$: any) => ({
+      data: Object.fromEntries(
+        ['version', 'pairingId', 'credId', 'requestId', 'wallet']
+          .filter((key) => _obs$[key] !== undefined)
+          .map((key) => [key, _obs$[key]]),
+      ),
+    });
+    if (process.env.NODE_ENV === 'test') {
+      globalThis.handleObserverMap = handleObserverMap;
+    }
+    return obs$.pipe(map(handleObserverMap));
   }
+
   @SubscribeMessage('offer-candidate')
   async onOfferCandidate(
     @MessageBody()
@@ -186,10 +391,9 @@ export class SignalsGateway
     @ConnectedSocket() client: Socket,
   ) {
     this.logger.debug(`(offer-candidate): ${JSON.stringify(data)}`);
-    const request = client.request as Record<string, any>;
-    await reloadSession(request.session);
-    const session = request.session as Session & Record<string, any>;
-    if (typeof session.wallet === 'string') {
+    if (await this.routePairingSignal('offer-candidate', data, client)) return;
+    const session = await this.legacySession(client);
+    if (typeof session?.wallet === 'string') {
       this.server.in(session.wallet).emit('offer-candidate', data);
     }
   }
@@ -200,36 +404,30 @@ export class SignalsGateway
     @ConnectedSocket() client: Socket,
   ) {
     this.logger.log(`(offer-description): ${data}`);
-    // Session from the initial Handshake
-    const request = client.request as Record<string, any>;
-    await reloadSession(request.session);
-    const session = request.session as Record<string, any>;
-
-    if (typeof session.wallet === 'string') {
-      if (!client.rooms.has(session.wallet)) {
-        client.join(session.wallet);
-      }
-      // Send description to all clients in the public key's room
+    if (await this.routePairingSignal('offer-description', data, client))
+      return;
+    const session = await this.legacySession(client);
+    if (typeof session?.wallet === 'string') {
+      if (!client.rooms.has(session.wallet)) await client.join(session.wallet);
       this.server.in(session.wallet).emit('offer-description', data);
     }
   }
+
   @SubscribeMessage('answer-description')
   async onAnswerDescription(
     @MessageBody() data: string,
     @ConnectedSocket() client: Socket,
   ) {
     this.logger.log(`(answer-description): ${data}`);
-    const request = client.request as Record<string, any>;
-    await reloadSession(request.session);
-
-    const session = request.session as Record<string, any>;
-    if (typeof session.wallet === 'string') {
-      if (!client.rooms.has(session.wallet)) {
-        client.join(session.wallet);
-      }
+    if (await this.routePairingSignal('answer-description', data, client))
+      return;
+    const session = await this.legacySession(client);
+    if (typeof session?.wallet === 'string') {
+      if (!client.rooms.has(session.wallet)) await client.join(session.wallet);
       this.server.in(session.wallet).emit('answer-description', data);
     }
   }
+
   @SubscribeMessage('answer-candidate')
   async onAnswerCandidate(
     @MessageBody()
@@ -237,16 +435,70 @@ export class SignalsGateway
     @ConnectedSocket() client: Socket,
   ) {
     this.logger.debug(`(answer-candidate): ${JSON.stringify(data)}`);
-    const request = client.request as Record<string, any>;
-    await reloadSession(request.session);
-
-    const session = request.session as Record<string, any>;
-    if (typeof session.wallet === 'string') {
-      if (!client.rooms.has(session.wallet)) {
-        client.join(session.wallet);
-      }
+    if (await this.routePairingSignal('answer-candidate', data, client)) return;
+    const session = await this.legacySession(client);
+    if (typeof session?.wallet === 'string') {
+      if (!client.rooms.has(session.wallet)) await client.join(session.wallet);
       this.logger.debug(`Sending (answer-candidate): ${JSON.stringify(data)}`);
       this.server.in(session.wallet).emit('answer-candidate', data);
+    }
+  }
+
+  private pairingContext(client: Socket): PairingSocketContext | undefined {
+    return client.data?.liquidPairing as PairingSocketContext | undefined;
+  }
+
+  private linkAuthorizationException(
+    error: PairingAuthorizationError,
+    data: { requestId: string },
+  ): WsException {
+    return new WsException({
+      status: 'error',
+      code: error.code,
+      message: error.message,
+      error: error.message,
+      cause: { pattern: 'link', data },
+    });
+  }
+
+  private async routePairingSignal(
+    event: string,
+    data: unknown,
+    client: Socket,
+  ): Promise<boolean> {
+    const context = this.pairingContext(client);
+    if (!context) return false;
+    const authentication = await this.pairingService.authenticateCredential(
+      context.pairingId,
+      context.role,
+      context.credential,
+    );
+    if (authentication.status !== 'active') {
+      throw new WsException('Pairing is not active');
+    }
+    const oppositeRole: PairingRole =
+      context.role === 'provider' ? 'controller' : 'provider';
+    this.server
+      .to(pairingRoleRoom(context.pairingId, oppositeRole))
+      .emit(event, data);
+    return true;
+  }
+
+  private async legacySession(
+    client: Socket,
+  ): Promise<(Session & Record<string, any>) | undefined> {
+    const request = client.request as Record<string, any>;
+    if (!request.session || typeof request.session.reload !== 'function') {
+      return request.session;
+    }
+    try {
+      await reloadSession(request.session);
+      return request.session as Session & Record<string, any>;
+    } catch (error) {
+      this.logger.warn(
+        `Unable to reload legacy signaling session: ${(error as Error).message}`,
+      );
+      return undefined;
     }
   }
 }

--- a/src/signals/signals.module.ts
+++ b/src/signals/signals.module.ts
@@ -4,9 +4,11 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { Session, SessionSchema } from '../auth/session.schema.js';
 import { User, UserSchema } from '../auth/auth.schema.js';
 import { AuthService } from '../auth/auth.service.js';
+import { PairingModule } from '../pairings/pairing.module.js';
 
 @Module({
   imports: [
+    PairingModule,
     MongooseModule.forFeature([
       { name: Session.name, schema: SessionSchema },
       { name: User.name, schema: UserSchema },


### PR DESCRIPTION
## Summary

- add durable provider/controller pairing credentials for reconnect authentication
- persist pairing authorization independently of a live Socket.IO/WebRTC session
- distinguish explicit pairing revocation or unauthorized credentials from transient signaling failures
- retain pairings until they are explicitly removed

## Why

A ping timeout, mobile suspension, server restart, or long offline period should only end the live transport. It should not silently invalidate an otherwise paired OpenClaw agent.

## Impact

Clients can reconnect after any length of absence using the persisted pairing credential, while an explicit removal still revokes access.

## Validation

- `pnpm exec jest --runInBand` — 131 tests passed
- `pnpm lint` — passed with two pre-existing warnings

## Release order

This server capability should be deployed before releasing the Liquid Client, AC2 plugin, and wallet changes that consume durable pairing authorization.
