### PR TITLE
feat: presence detection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -221,9 +221,15 @@ The server will acknowledge the request when the `microservice:auth` event is re
 const response: LinkMessage = await client.link(requestId)
 ```
 
+Both the `wss:link` client and the authenticated wallet are joined to a room named after
+the `requestId`. All signaling below is brokered to that room rather than the wallet
+address, so negotiation works before the peer has authenticated and no longer depends on
+the wallet identity.
+
 #### wss:offer-description | wss:answer-description
 
-Wait for the server to emit an offer or answer description to the client.
+Wait for the server to emit an offer or answer description to the client. Emitted to the
+`requestId` room.
 
 ```typescript
 const response: string = await client.signal('offer' | 'answer')
@@ -231,11 +237,30 @@ const response: string = await client.signal('offer' | 'answer')
 
 #### wss:offer-candidate | wss:answer-candidate
 
-Emits the offer or answer ICE Candidates to connected clients.
+Emits the offer or answer ICE Candidates to the `requestId` room.
 
 ```typescript
 client.peerClient.onicecandidate=(event)=>{
   client.socket.emit('offer-candidate', event.candidate.toJSON())
 }
 
+```
+
+#### wss:presence
+
+Broadcast to the `requestId` room whenever a socket joins or leaves it, and also
+returned as the acknowledgement of an on-demand `presence` request. Lets a peer detect
+whether the other party is available before attempting to (re)negotiate; peers only
+negotiate once both are present (`deviceCount >= 2`).
+
+`deviceCount` counts distinct devices (sockets are collapsed by their session id, so a
+device that briefly owns multiple sockets is only counted once) and `online` is `true`
+when at least one device is present. `GET /auth/session` reports the same live
+`deviceCount`. Because both peers persist the `requestId` and the wallet keeps a valid
+session, a dropped connection is renegotiated over the socket without a fresh passkey
+prompt once presence shows both peers again.
+
+```typescript
+const presence: { requestId: string; deviceCount: number; online: boolean } =
+  await client.socket.emitWithAck('presence', { requestId })
 ```

--- a/SEQUENCE.md
+++ b/SEQUENCE.md
@@ -1,6 +1,12 @@
 
 ## Sequence Diagram
 
+All signaling for a pairing is keyed on the `requestId`. When a client subscribes to
+`wss:link` (or a wallet authenticates against a `requestId`) its socket joins the
+`requestId` room. Session Descriptions and ICE Candidates are then brokered to that
+room, so negotiation no longer depends on the wallet address and works before the
+peer has authenticated.
+
 ```mermaid
 sequenceDiagram
     participant Website
@@ -8,15 +14,23 @@ sequenceDiagram
     participant Wallet
     Note over Website, Wallet: Link devices
     Website->>Server: Subscribe to 'wss:link'
+    Server-->>Server: Join Website socket to `requestId` room
     Website-->>Website: Display QR Connect Request ID
     Wallet->>Website: Scan QR Code
     Server-->>Wallet: Get Challenge/Options
     Wallet->>Server: POST FIDO2 Credential + Liquid Auth Extension
     Server-->>Server: Validate Signatures
+    Server-->>Server: Persist `requestId` on Wallet session, join Wallet socket to `requestId` room
     Server-->>Website: HTTPOnly Session
     Server->>Wallet: Ok Response + HTTPOnly Session
-    Server->>Website: Emit to `wss:link` client
-    Note over Website, Wallet: Signaling Channels
+    Server->>Website: Emit `microservice:auth` to resolve `wss:link`
+
+    Note over Website, Wallet: Presence (focused on the requestId)
+    Server-->>Website: Broadcast `wss:presence` { requestId, deviceCount, online }
+    Server-->>Wallet: Broadcast `wss:presence` { requestId, deviceCount, online }
+    Note over Website, Wallet: Peers only negotiate once both are present (deviceCount ≥ 2)
+
+    Note over Website, Wallet: Signaling Channels (requestId room)
     Website-->>Server: Subscribe to 'wss:offer-description'
     Website-->>Server: Subscribe to 'wss:offer-candidate'
     Wallet-->>Server: Subscribe to 'wss:answer-description'
@@ -26,16 +40,48 @@ sequenceDiagram
     Wallet-->>Wallet: On answer-description, set Remote SDP
     Wallet-->>Wallet: On answer-candidate, add ICE Candidate
     Wallet-->>Wallet: Create Peer Offer & DataChannel
-    Wallet-->>Server: Emit `wss:offer-description`
-    Wallet-->>Server: Emit `wss:offer-candidate`
+    Wallet-->>Server: Emit `wss:offer-description` (to `requestId` room)
+    Wallet-->>Server: Emit `wss:offer-candidate` (to `requestId` room)
 
     Note over Website, Wallet: Peer Answer
     Website-->>Website: On offer-description, set Remote SDP and create Answer
     Website-->>Website: On offer-candidate, add ICE Candidate
-    Website-->>Server: Emit `wss:answer-description`
-    Website-->>Server: Emit `wss:answer-candidate`
+    Website-->>Server: Emit `wss:answer-description` (to `requestId` room)
+    Website-->>Server: Emit `wss:answer-candidate` (to `requestId` room)
 
     Note over Website, Wallet: Data Channel
     Website-->>Wallet: On DataChannel, Emit Messages
+```
 
+## Presence & Reconnection
+
+Every connection change broadcasts a `wss:presence` event to the `requestId` room so
+peers can tell whether the other party is available before attempting to (re)negotiate.
+`deviceCount` counts distinct devices (collapsed by session id, so one device that owns
+several sockets is only counted once), and `online` is `true` when at least one device
+is present. `GET /auth/session` reports the same live `deviceCount`. An offline client
+uses this to decide whether it should even attempt to reconnect.
+
+Because both peers persist the `requestId` and the wallet keeps a valid session, a
+dropped connection is renegotiated over the existing socket without a fresh passkey
+prompt: the server re-announces `auth` when a bound wallet reconnects (or when the peer
+links while the wallet is already present), and both sides re-run the offer/answer
+exchange in the `requestId` room.
+
+```mermaid
+sequenceDiagram
+    participant Website
+    participant Server
+    participant Wallet
+    Note over Website, Wallet: Both previously paired (share requestId + valid session)
+    Wallet--xServer: Connection dropped
+    Server-->>Website: Broadcast `wss:presence` { deviceCount: 1, online: true }
+    Website-->>Website: Peer offline — tear down transport, keep socket & wait
+    Wallet->>Server: Reconnect socket (session still valid, no passkey prompt)
+    Server-->>Server: Re-join Wallet to `requestId` room, re-announce `auth`
+    Server-->>Website: Broadcast `wss:presence` { deviceCount: 2, online: true }
+    Note over Website, Wallet: Both present — renegotiate over the socket
+    Wallet-->>Server: Emit `wss:offer-description` / `wss:offer-candidate`
+    Website-->>Server: Emit `wss:answer-description` / `wss:answer-candidate`
+    Website-->>Wallet: DataChannel re-established
 ```

--- a/docs/src/content/docs/architecture.md
+++ b/docs/src/content/docs/architecture.md
@@ -38,6 +38,12 @@ sequenceDiagram
 The website and wallet can subscribe to an isolated WebSocket channel to broker [Session Description]() answers and offers.
 [ICE Candidates]() are discovered when any peer has both an offer and answer.
 
+Signaling is keyed on the `requestId` rather than the wallet address. When a client
+subscribes to `wss:link`, and when a wallet authenticates against a `requestId`, the
+server joins that socket to the `requestId` room. Descriptions and candidates are then
+brokered to that room, so negotiation works before the peer has authenticated and no
+longer depends on the wallet address.
+
 ```mermaid
 sequenceDiagram
     participant Website as Answer Client
@@ -98,4 +104,51 @@ sequenceDiagram
     Website-->>Website: On DataChannel, listen for Messages
     Website-->>Wallet: Emit Messages
     Wallet-->>Website: Emit Messages
+```
+
+## Presence
+
+Whenever a socket joins or leaves a `requestId` room the server broadcasts a
+`wss:presence` event to that room. Peers use it to decide whether the other party is
+available before attempting to (re)negotiate, and only negotiate once both peers are
+present (`deviceCount >= 2`).
+
+`deviceCount` counts distinct devices — sockets are collapsed by their session id, so a
+device that briefly owns more than one socket (e.g. a lingering socket plus a fresh
+reconnect) is only counted once. `online` is `true` when at least one device is present.
+`GET /auth/session` reports the same live `deviceCount`.
+
+```mermaid
+sequenceDiagram
+    participant Website as Answer Client
+    participant Server
+    participant Wallet as Offer Client
+    Wallet->>Server: Connect / authenticate for `requestId`
+    Server-->>Server: Join `requestId` room, count distinct devices
+    Server-->>Website: Emit `wss:presence` { requestId, deviceCount, online }
+    Server-->>Wallet: Emit `wss:presence` { requestId, deviceCount, online }
+    Note over Website, Wallet: Negotiate only when deviceCount ≥ 2
+```
+
+## Reconnection
+
+Because both peers persist the `requestId` and the wallet retains a valid session, a
+dropped P2P connection is renegotiated over the existing socket without a fresh passkey
+prompt. The server re-announces `auth` when a bound wallet reconnects (or when the peer
+links while the wallet is already present), and both sides re-run the offer/answer
+exchange in the `requestId` room.
+
+```mermaid
+sequenceDiagram
+    participant Website as Answer Client
+    participant Server
+    participant Wallet as Offer Client
+    Note over Website, Wallet: Previously paired (share requestId + valid session)
+    Wallet--xServer: Connection dropped
+    Server-->>Website: Emit `wss:presence` { deviceCount: 1, online: true }
+    Website-->>Website: Peer offline — tear down transport, keep socket & wait
+    Wallet->>Server: Reconnect socket (no passkey prompt)
+    Server-->>Server: Re-join `requestId` room, re-announce `auth`
+    Server-->>Website: Emit `wss:presence` { deviceCount: 2, online: true }
+    Note over Website, Wallet: Both present — renegotiate and re-establish the Data Channel
 ```

--- a/src/__mocks__/auth.service.mock.ts
+++ b/src/__mocks__/auth.service.mock.ts
@@ -11,5 +11,7 @@ export const mockAuthService = {
   findCredential: jest.fn().mockResolvedValue(dummyUser.credentials[0]),
   addCredential: jest.fn().mockResolvedValue(dummyUser),
   removeCredential: jest.fn().mockResolvedValue(dummyUser),
+  findAuthenticatedSessionByRequestId: jest.fn().mockResolvedValue(null),
+  findSessionsByCredId: jest.fn().mockResolvedValue([]),
   all: jest.fn().mockResolvedValue(dummyUsers),
 };

--- a/src/__mocks__/auth.service.mock.ts
+++ b/src/__mocks__/auth.service.mock.ts
@@ -11,6 +11,7 @@ export const mockAuthService = {
   findCredential: jest.fn().mockResolvedValue(dummyUser.credentials[0]),
   addCredential: jest.fn().mockResolvedValue(dummyUser),
   removeCredential: jest.fn().mockResolvedValue(dummyUser),
+  findAuthenticatedSessionsByRequestId: jest.fn().mockResolvedValue([]),
   findAuthenticatedSessionByRequestId: jest.fn().mockResolvedValue(null),
   findSessionsByCredId: jest.fn().mockResolvedValue([]),
   all: jest.fn().mockResolvedValue(dummyUsers),

--- a/src/assertion/assertion.controller.ts
+++ b/src/assertion/assertion.controller.ts
@@ -175,6 +175,12 @@ export class AssertionController {
 
     delete session.challenge;
     session.wallet = user.wallet;
+    // Device identity: remember the credential this session asserted with. A
+    // credId can only ever belong to a single device, so the auth event below
+    // lets the gateway kick out any other (stale) session bound to the same
+    // credId. Without this the same device asserting again (a fresh login/link)
+    // would be counted as an extra device on every login, inflating presence.
+    session.credId = body.id;
     // Presence: remember the requestId on the wallet's own session so that
     // when its signaling socket (re)connects, handleConnection joins it to the
     // requestId room and it is counted as a connected device.
@@ -182,7 +188,9 @@ export class AssertionController {
     if (typeof requestId === 'string' && requestId.length > 0) {
       session.requestId = requestId;
     }
-    // Emit the signin event for the given request id
+    // Emit the signin event for the given request id. `credId` tells the
+    // gateway to kick out any other (stale) session bound to the same
+    // credential (see evictDuplicateCredentialSessions).
     this.client.emit<string>('auth', {
       requestId,
       wallet: user.wallet,

--- a/src/assertion/assertion.controller.ts
+++ b/src/assertion/assertion.controller.ts
@@ -175,9 +175,16 @@ export class AssertionController {
 
     delete session.challenge;
     session.wallet = user.wallet;
+    // Presence: remember the requestId on the wallet's own session so that
+    // when its signaling socket (re)connects, handleConnection joins it to the
+    // requestId room and it is counted as a connected device.
+    const requestId = body?.clientExtensionResults?.liquid?.requestId;
+    if (typeof requestId === 'string' && requestId.length > 0) {
+      session.requestId = requestId;
+    }
     // Emit the signin event for the given request id
     this.client.emit<string>('auth', {
-      requestId: body?.clientExtensionResults?.liquid?.requestId,
+      requestId,
       wallet: user.wallet,
       credId: body.id,
       sessionId: session.id,

--- a/src/attestation/attestation.controller.spec.ts
+++ b/src/attestation/attestation.controller.spec.ts
@@ -124,6 +124,9 @@ describe('AttestationController', () => {
       expect(session.wallet).toEqual(
         attestationResponseResponseFixtures[0].wallet,
       );
+      // The session records the credential it authenticated with so the gateway
+      // can kick out any other (stale) session bound to the same credential.
+      expect(session.credId).toEqual(body.id);
       expect(mockAccountLinkService.emit).toHaveBeenCalledWith('auth', {
         requestId: body.clientExtensionResults.liquid.requestId,
         wallet: body.clientExtensionResults.liquid.address,

--- a/src/attestation/attestation.controller.ts
+++ b/src/attestation/attestation.controller.ts
@@ -132,6 +132,13 @@ export class AttestationController {
     delete session.challenge;
     // Authorize user with a wallet session
     session.wallet = username;
+    // Device identity: remember the credential this session authenticated with.
+    // A credId can only ever belong to a single device, so the auth event below
+    // lets the gateway kick out any other (stale) session bound to the same
+    // credId. This deduplicates a device — e.g. a legacy application that
+    // re-attests on every connection — so it always counts as a single device,
+    // while other devices sharing the same wallet address are left alone.
+    session.credId = credential.credId;
     // Presence: remember the requestId on the wallet's own session so that
     // when its signaling socket (re)connects, handleConnection joins it to the
     // requestId room and it is counted as a connected device.
@@ -139,7 +146,9 @@ export class AttestationController {
     if (typeof requestId === 'string' && requestId.length > 0) {
       session.requestId = requestId;
     }
-    // Handle Liquid Extension
+    // Handle Liquid Extension. `credId` tells the gateway to kick out any other
+    // (stale) session bound to the same credential (see
+    // evictDuplicateCredentialSessions).
     this.client.emit<string>('auth', {
       requestId,
       wallet: user.wallet,

--- a/src/attestation/attestation.controller.ts
+++ b/src/attestation/attestation.controller.ts
@@ -132,9 +132,16 @@ export class AttestationController {
     delete session.challenge;
     // Authorize user with a wallet session
     session.wallet = username;
+    // Presence: remember the requestId on the wallet's own session so that
+    // when its signaling socket (re)connects, handleConnection joins it to the
+    // requestId room and it is counted as a connected device.
+    const requestId = body?.clientExtensionResults?.liquid?.requestId;
+    if (typeof requestId === 'string' && requestId.length > 0) {
+      session.requestId = requestId;
+    }
     // Handle Liquid Extension
     this.client.emit<string>('auth', {
-      requestId: body?.clientExtensionResults?.liquid?.requestId,
+      requestId,
       wallet: user.wallet,
       credId: credential.credId,
       sessionId: session.id,

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller.js';
 import { AuthService } from './auth.service.js';
+import { SignalsGateway } from '../signals/signals.gateway.js';
 import { Session } from './session.schema.js';
 import mongoose, { Error, Model } from 'mongoose';
 import { User, UserSchema } from './auth.schema.js';
@@ -17,10 +18,12 @@ import {
 describe('AuthController', () => {
   let authController: AuthController;
   let authService: AuthService;
+  let signalsGateway: { countDevices: jest.Mock };
   let userModel: Model<User>;
 
   beforeEach(async () => {
     userModel = mongoose.model('User', UserSchema);
+    signalsGateway = { countDevices: jest.fn().mockResolvedValue(0) };
 
     const moduleRef: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
@@ -28,6 +31,10 @@ describe('AuthController', () => {
         {
           provide: AuthService,
           useValue: { ...mockAuthService },
+        },
+        {
+          provide: SignalsGateway,
+          useValue: signalsGateway,
         },
         {
           provide: getModelToken(User.name),
@@ -132,6 +139,20 @@ describe('AuthController', () => {
       await expect(
         authController.read(sessionFixtures.authorized),
       ).resolves.toEqual({ session: sessionFixtures.authorized, user: null });
+    });
+
+    it('(OK) should report the live device count for the session requestId', async () => {
+      signalsGateway.countDevices.mockResolvedValueOnce(2);
+      const session = {
+        wallet: sessionFixtures.authorized.wallet,
+        requestId: '019097ff-bb8c-7d5d-9822-7c9eb2c0d419',
+        deviceCount: 1,
+      } as Record<string, any>;
+      const result = await authController.read(session);
+      expect(signalsGateway.countDevices).toHaveBeenCalledWith(
+        '019097ff-bb8c-7d5d-9822-7c9eb2c0d419',
+      );
+      expect(result.session.deviceCount).toBe(2);
     });
   });
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -21,11 +21,15 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { User } from './auth.schema.js';
+import { SignalsGateway } from '../signals/signals.gateway.js';
 
 @Controller('auth')
 @ApiTags('auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private signalsGateway: SignalsGateway,
+  ) {}
 
   /**
    * Display user keys
@@ -97,6 +101,16 @@ export class AuthController {
   @ApiOperation({ summary: 'Get Session' })
   async read(@Session() session: Record<string, any>) {
     const user = await this.authService.find(session.wallet);
+    // Presence: report the live device count for this session's requestId
+    // rather than a value persisted earlier. Counting on read avoids the race
+    // where a peer joined the request room after the last persisted update, so
+    // the session information always reflects how many devices are currently
+    // connected (used to decide whether an offline client should reconnect).
+    if (typeof session.requestId === 'string' && session.requestId.length > 0) {
+      session.deviceCount = await this.signalsGateway.countDevices(
+        session.requestId,
+      );
+    }
     return {
       user: user
         ? {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -89,6 +89,7 @@ export class AuthController {
   logout(@Session() session: Record<string, any>, @Res() res: Response) {
     delete session.wallet;
     delete session.active;
+    delete session.credId;
     delete session.requestId;
     res.redirect(302, '/');
   }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -4,6 +4,7 @@ import { AuthService } from './auth.service.js';
 import { MongooseModule } from '@nestjs/mongoose';
 import { User, UserSchema } from './auth.schema.js';
 import { Session, SessionSchema } from './session.schema.js';
+import { SignalsModule } from '../signals/signals.module.js';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { Session, SessionSchema } from './session.schema.js';
       { name: User.name, schema: UserSchema },
       { name: Session.name, schema: SessionSchema },
     ]),
+    SignalsModule,
   ],
   controllers: [AuthController],
   providers: [AuthService],

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -48,6 +48,9 @@ describe('AuthService', () => {
     mockSessionModel.findOneAndUpdate = jest.fn().mockReturnValue({
       exec: jest.fn().mockResolvedValue(mockSession),
     });
+    mockSessionModel.find = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue([]),
+    });
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         {
@@ -126,5 +129,89 @@ describe('AuthService', () => {
       mockUser.wallet,
     );
     expect(session).toEqual(mockSession);
+  });
+  it('should find an authenticated session by requestId', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    mockSessionModel.find = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue([
+        {
+          _id: mockSession._id,
+          session: JSON.stringify({ requestId, wallet: mockUser.wallet }),
+        },
+      ]),
+    });
+    const result = await service.findAuthenticatedSessionByRequestId(requestId);
+    expect(result).toEqual({
+      sessionId: mockSession._id,
+      wallet: mockUser.wallet,
+    });
+  });
+  it('should return null for an empty requestId', async () => {
+    await expect(
+      service.findAuthenticatedSessionByRequestId(''),
+    ).resolves.toBeNull();
+  });
+  it('should exclude the caller session when finding the other party', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    mockSessionModel.find = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue([
+        {
+          _id: 'offer-session-id',
+          session: JSON.stringify({ requestId, wallet: mockUser.wallet }),
+        },
+        {
+          _id: 'wallet-session-id',
+          session: JSON.stringify({ requestId, wallet: mockUser.wallet }),
+        },
+      ]),
+    });
+    const result = await service.findAuthenticatedSessionByRequestId(
+      requestId,
+      'offer-session-id',
+    );
+    expect(result).toEqual({
+      sessionId: 'wallet-session-id',
+      wallet: mockUser.wallet,
+    });
+  });
+  it('should return null when no session carries a wallet for the requestId', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    mockSessionModel.find = jest.fn().mockReturnValue({
+      exec: jest
+        .fn()
+        .mockResolvedValue([
+          { _id: mockSession._id, session: JSON.stringify({ requestId }) },
+        ]),
+    });
+    await expect(
+      service.findAuthenticatedSessionByRequestId(requestId),
+    ).resolves.toBeNull();
+  });
+  it('should find other sessions bound to the same credential, excluding the kept one', async () => {
+    const credId = 'a-credential-id';
+    mockSessionModel.find = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue([
+        {
+          _id: 'new-session',
+          session: JSON.stringify({ wallet: mockUser.wallet, credId }),
+        },
+        {
+          _id: 'stale-session',
+          session: JSON.stringify({ wallet: mockUser.wallet, credId }),
+        },
+        {
+          _id: 'other-device-session',
+          session: JSON.stringify({
+            wallet: mockUser.wallet,
+            credId: 'a-different-credential',
+          }),
+        },
+      ]),
+    });
+    const result = await service.findSessionsByCredId(credId, 'new-session');
+    expect(result).toEqual(['stale-session']);
+  });
+  it('should return no sessions for an empty credId', async () => {
+    await expect(service.findSessionsByCredId('')).resolves.toEqual([]);
   });
 });

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -187,6 +187,61 @@ describe('AuthService', () => {
       service.findAuthenticatedSessionByRequestId(requestId),
     ).resolves.toBeNull();
   });
+  it('should return ALL authenticated sessions bound to a requestId', async () => {
+    // Repeated restarts accumulate several sessions with the same requestId +
+    // wallet; the plural lookup must surface every one so the caller can pick
+    // the one that is genuinely present instead of bailing on the first.
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    mockSessionModel.find = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue([
+        {
+          _id: 'stale-session-id',
+          session: JSON.stringify({ requestId, wallet: mockUser.wallet }),
+        },
+        {
+          _id: 'live-session-id',
+          session: JSON.stringify({ requestId, wallet: mockUser.wallet }),
+        },
+        {
+          _id: 'no-wallet-session-id',
+          session: JSON.stringify({ requestId }),
+        },
+      ]),
+    });
+    const result =
+      await service.findAuthenticatedSessionsByRequestId(requestId);
+    expect(result).toEqual([
+      { sessionId: 'stale-session-id', wallet: mockUser.wallet },
+      { sessionId: 'live-session-id', wallet: mockUser.wallet },
+    ]);
+  });
+  it('should exclude the caller session from all matches', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    mockSessionModel.find = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue([
+        {
+          _id: 'offer-session-id',
+          session: JSON.stringify({ requestId, wallet: mockUser.wallet }),
+        },
+        {
+          _id: 'wallet-session-id',
+          session: JSON.stringify({ requestId, wallet: mockUser.wallet }),
+        },
+      ]),
+    });
+    const result = await service.findAuthenticatedSessionsByRequestId(
+      requestId,
+      'offer-session-id',
+    );
+    expect(result).toEqual([
+      { sessionId: 'wallet-session-id', wallet: mockUser.wallet },
+    ]);
+  });
+  it('should return an empty array of sessions for an empty requestId', async () => {
+    await expect(
+      service.findAuthenticatedSessionsByRequestId(''),
+    ).resolves.toEqual([]);
+  });
   it('should find other sessions bound to the same credential, excluding the kept one', async () => {
     const credId = 'a-credential-id';
     mockSessionModel.find = jest.fn().mockReturnValue({

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -105,36 +105,44 @@ export class AuthService {
   }
 
   /**
-   * Find an authenticated Session bound to a requestId
+   * Find ALL authenticated Sessions bound to a requestId
    *
-   * Looks up a stored session whose serialized data is tied to the given
+   * Looks up every stored session whose serialized data is tied to the given
    * requestId and already carries an authenticated wallet. Used to drive an
    * order-independent pairing rendezvous: when a peer links for a requestId a
    * wallet has already authenticated for, the caller can re-announce that wallet
    * (gated on live presence) so the peer resolves regardless of who connected
    * first.
    *
+   * Returning EVERY match (rather than just the first) is what makes the
+   * rendezvous robust to stale duplicate sessions: repeated peer/app restarts
+   * accumulate several sessions carrying the same requestId + wallet, only one
+   * of which still owns a live socket. The caller can then scan these
+   * candidates and re-announce the one that is genuinely present, instead of
+   * giving up when the first (possibly dead) match has no socket.
+   *
    * @param requestId - The request identifier peers are connecting for
    * @param excludeSessionId - A session id to ignore (e.g. the linking peer's
    *   own session, which after a first pairing also carries the wallet), so the
-   *   result identifies the OTHER party
-   * @returns The wallet + sessionId when found, otherwise null
+   *   results identify the OTHER party
+   * @returns The wallet + sessionId of every match, in stored order (may be empty)
    */
-  async findAuthenticatedSessionByRequestId(
+  async findAuthenticatedSessionsByRequestId(
     requestId: string,
     excludeSessionId?: string,
-  ): Promise<{ sessionId: string; wallet: string } | null> {
+  ): Promise<{ sessionId: string; wallet: string }[]> {
     if (typeof requestId !== 'string' || requestId.length === 0) {
-      return null;
+      return [];
     }
     // The session payload is stored as a JSON string, so narrow the scan with a
     // substring match on the requestId before parsing each candidate.
     const sessions = await this.sessionModel
       .find({ session: { $regex: requestId } })
       .exec();
+    const matches: { sessionId: string; wallet: string }[] = [];
     for (const stored of sessions) {
       const sessionId = String(stored._id);
-      // Skip the caller's own session so the match identifies the other peer
+      // Skip the caller's own session so the matches identify the other peer
       // (both peers share the same wallet + requestId after a first pairing).
       if (excludeSessionId && sessionId === excludeSessionId) {
         continue;
@@ -147,13 +155,37 @@ export class AuthService {
           typeof data.wallet === 'string' &&
           data.wallet.length > 0
         ) {
-          return { sessionId, wallet: data.wallet };
+          matches.push({ sessionId, wallet: data.wallet });
         }
       } catch {
         // Skip sessions whose payload can't be parsed.
       }
     }
-    return null;
+    return matches;
+  }
+
+  /**
+   * Find an authenticated Session bound to a requestId
+   *
+   * Convenience wrapper over {@link findAuthenticatedSessionsByRequestId} that
+   * returns only the first match (or null). Prefer the plural form when the
+   * caller needs to skip stale sessions and pick the one that is genuinely
+   * present.
+   *
+   * @param requestId - The request identifier peers are connecting for
+   * @param excludeSessionId - A session id to ignore (e.g. the linking peer's
+   *   own session)
+   * @returns The wallet + sessionId of the first match, otherwise null
+   */
+  async findAuthenticatedSessionByRequestId(
+    requestId: string,
+    excludeSessionId?: string,
+  ): Promise<{ sessionId: string; wallet: string } | null> {
+    const [first] = await this.findAuthenticatedSessionsByRequestId(
+      requestId,
+      excludeSessionId,
+    );
+    return first ?? null;
   }
 
   /**

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -105,6 +105,105 @@ export class AuthService {
   }
 
   /**
+   * Find an authenticated Session bound to a requestId
+   *
+   * Looks up a stored session whose serialized data is tied to the given
+   * requestId and already carries an authenticated wallet. Used to drive an
+   * order-independent pairing rendezvous: when a peer links for a requestId a
+   * wallet has already authenticated for, the caller can re-announce that wallet
+   * (gated on live presence) so the peer resolves regardless of who connected
+   * first.
+   *
+   * @param requestId - The request identifier peers are connecting for
+   * @param excludeSessionId - A session id to ignore (e.g. the linking peer's
+   *   own session, which after a first pairing also carries the wallet), so the
+   *   result identifies the OTHER party
+   * @returns The wallet + sessionId when found, otherwise null
+   */
+  async findAuthenticatedSessionByRequestId(
+    requestId: string,
+    excludeSessionId?: string,
+  ): Promise<{ sessionId: string; wallet: string } | null> {
+    if (typeof requestId !== 'string' || requestId.length === 0) {
+      return null;
+    }
+    // The session payload is stored as a JSON string, so narrow the scan with a
+    // substring match on the requestId before parsing each candidate.
+    const sessions = await this.sessionModel
+      .find({ session: { $regex: requestId } })
+      .exec();
+    for (const stored of sessions) {
+      const sessionId = String(stored._id);
+      // Skip the caller's own session so the match identifies the other peer
+      // (both peers share the same wallet + requestId after a first pairing).
+      if (excludeSessionId && sessionId === excludeSessionId) {
+        continue;
+      }
+      try {
+        const data = JSON.parse(stored.session);
+        if (
+          data &&
+          data.requestId === requestId &&
+          typeof data.wallet === 'string' &&
+          data.wallet.length > 0
+        ) {
+          return { sessionId, wallet: data.wallet };
+        }
+      } catch {
+        // Skip sessions whose payload can't be parsed.
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Find other sessions bound to the same credential
+   *
+   * A credential (`credId`) can only ever belong to a single device, so any
+   * OTHER stored session that carries the same `credId` must be a stale login
+   * from that same device (e.g. a legacy application that re-authenticates on
+   * every connection, or a wallet that logs in again). Locating them lets a
+   * freshly authenticated session kick them out so the device is always counted
+   * once — while leaving other devices that merely share the wallet
+   * address untouched (a wallet key may live on many devices).
+   *
+   * @param credId - The credential id that identifies the device
+   * @param excludeSessionId - A session id to ignore (e.g. the freshly
+   *   authenticated session, which is the one we want to keep)
+   * @returns The session ids of the other sessions bound to the same credential
+   */
+  async findSessionsByCredId(
+    credId: string,
+    excludeSessionId?: string,
+  ): Promise<string[]> {
+    if (typeof credId !== 'string' || credId.length === 0) {
+      return [];
+    }
+    // The session payload is stored as a JSON string, so narrow the scan with a
+    // substring match on the credId before parsing each candidate.
+    const sessions = await this.sessionModel
+      .find({ session: { $regex: credId } })
+      .exec();
+    const ids: string[] = [];
+    for (const stored of sessions) {
+      const sessionId = String(stored._id);
+      // Keep the freshly authenticated session.
+      if (excludeSessionId && sessionId === excludeSessionId) {
+        continue;
+      }
+      try {
+        const data = JSON.parse(stored.session);
+        if (data && data.credId === credId) {
+          ids.push(sessionId);
+        }
+      } catch {
+        // Skip sessions whose payload can't be parsed.
+      }
+    }
+    return ids;
+  }
+
+  /**
    * Update Wallet by Session ID
    * @param session - The stored Session
    * @param wallet - The Wallet Address

--- a/src/signals/signals.gateway.spec.ts
+++ b/src/signals/signals.gateway.spec.ts
@@ -19,6 +19,7 @@ const clientMock = {
   },
   rooms: new Set(),
   join: jest.fn(),
+  data: {},
 } as unknown as Socket;
 let linkEventFn: any;
 const ioAdapterMock = {
@@ -102,7 +103,10 @@ describe('SignalsGateway', () => {
   });
   it('should join an authenticated session to the requestId room on a global auth event', async () => {
     const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
-    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([{}, {}]);
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([
+      { data: { sessionId: 'a' } },
+      { data: { sessionId: 'b' } },
+    ]);
     gateway.afterInit(gateway.server);
     await linkEventFn(
       'auth',
@@ -133,6 +137,7 @@ describe('SignalsGateway', () => {
         sessionID: 'unauthorized-session-id',
       },
       join: jest.fn(),
+      data: {},
     } as unknown as Socket);
     // @ts-expect-error, testing purposes
     expect(gateway.logger.debug).toHaveBeenCalled();
@@ -147,8 +152,8 @@ describe('SignalsGateway', () => {
   });
   it('should count devices and persist presence to the session', async () => {
     (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([
-      {},
-      {},
+      { data: { sessionId: 'a' } },
+      { data: { sessionId: 'b' } },
     ]);
     const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
     const deviceCount = await gateway.updatePresence(
@@ -166,6 +171,17 @@ describe('SignalsGateway', () => {
     expect((sessionFixtures.authorized as any).deviceCount).toBe(2);
     expect((sessionFixtures.authorized as any).save).toHaveBeenCalled();
   });
+  it('should count the same device once even with multiple sockets', async () => {
+    // A single device (session) that reconnects can briefly own more than one
+    // socket in the room. Presence must collapse them by session id so the
+    // device is only ever counted once, no matter how it reconnects.
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([
+      { data: { sessionId: 'same-device' } },
+      { data: { sessionId: 'same-device' } },
+    ]);
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    await expect(gateway.countDevices(requestId)).resolves.toBe(1);
+  });
   it('should refresh presence on disconnect when a requestId is present', async () => {
     const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
     const session = { requestId, save: jest.fn() };
@@ -180,7 +196,10 @@ describe('SignalsGateway', () => {
     expect(session.save).toHaveBeenCalled();
   });
   it('should respond to a presence request', async () => {
-    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([{}, {}]);
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([
+      { data: { sessionId: 'a' } },
+      { data: { sessionId: 'b' } },
+    ]);
     const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
     const result = await gateway.onPresence({ requestId }, clientMock);
     expect(result).toStrictEqual({
@@ -193,6 +212,12 @@ describe('SignalsGateway', () => {
       deviceCount: 2,
       online: true,
     });
+    // A presence query is a pure read: it must NOT persist the requestId onto
+    // the querying client's session, otherwise that client would auto-join the
+    // requestId room on its next (re)connect and be counted as a device even
+    // though it never linked and cannot receive a connection.
+    expect((sessionFixtures.authorized as any).save).not.toHaveBeenCalled();
+    expect((sessionFixtures.authorized as any).requestId).toBeUndefined();
   });
   it('should handle a link event', async () => {
     const obs = await gateway.link(
@@ -201,7 +226,10 @@ describe('SignalsGateway', () => {
     );
     obs.subscribe();
 
-    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([{}, {}]);
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([
+      { data: { sessionId: 'a' } },
+      { data: { sessionId: 'b' } },
+    ]);
     await linkEventFn(
       'auth',
       JSON.stringify({
@@ -247,6 +275,93 @@ describe('SignalsGateway', () => {
       },
     });
   });
+  it('should re-announce auth on link when a wallet is genuinely present', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    (gateway as any).authService.findAuthenticatedSessionByRequestId = jest
+      .fn()
+      .mockResolvedValue({
+        sessionId: 'wallet-session-id',
+        wallet: sessionFixtures.authorized.wallet,
+      });
+    // The wallet's own session still owns a live socket → genuinely present.
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([{}]);
+    await gateway.reannounceIfWalletPresent(requestId);
+    expect(gateway.server.in).toHaveBeenCalledWith('wallet-session-id');
+    expect((gateway as any).client.emit).toHaveBeenCalledWith('auth', {
+      requestId,
+      wallet: sessionFixtures.authorized.wallet,
+      sessionId: 'wallet-session-id',
+    });
+  });
+  it('should kick out stale sessions bound to the same credential', async () => {
+    const credId = 'a-credential-id';
+    (gateway as any).authService.findSessionsByCredId = jest
+      .fn()
+      .mockResolvedValue(['stale-session']);
+    const disconnect = jest.fn();
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([
+      { disconnect },
+    ]);
+    await gateway.evictDuplicateCredentialSessions(credId, 'new-session');
+    expect(
+      (gateway as any).authService.findSessionsByCredId,
+    ).toHaveBeenCalledWith(credId, 'new-session');
+    expect(gateway.server.in).toHaveBeenCalledWith('stale-session');
+    expect(disconnect).toHaveBeenCalledWith(true);
+  });
+  it('should evict duplicate credential sessions on a global auth event with a credId', async () => {
+    const credId = 'a-credential-id';
+    const evictSpy = jest
+      .spyOn(gateway, 'evictDuplicateCredentialSessions')
+      .mockResolvedValue();
+    gateway.afterInit(gateway.server);
+    await linkEventFn(
+      'auth',
+      JSON.stringify({
+        sessionId: 'new-session',
+        wallet: sessionFixtures.authorized.wallet,
+        credId,
+      }),
+    );
+    expect(evictSpy).toHaveBeenCalledWith(credId, 'new-session');
+  });
+  it('should not evict when the auth event carries no credId', async () => {
+    const evictSpy = jest
+      .spyOn(gateway, 'evictDuplicateCredentialSessions')
+      .mockResolvedValue();
+    gateway.afterInit(gateway.server);
+    await linkEventFn(
+      'auth',
+      JSON.stringify({
+        sessionId: 'wallet-session-id',
+        wallet: sessionFixtures.authorized.wallet,
+      }),
+    );
+    expect(evictSpy).not.toHaveBeenCalled();
+  });
+  it('should not re-announce auth on link when no wallet session exists', async () => {
+    (gateway as any).authService.findAuthenticatedSessionByRequestId = jest
+      .fn()
+      .mockResolvedValue(null);
+    await gateway.reannounceIfWalletPresent(
+      '019097ff-bb8c-7d5d-9822-7c9eb2c0d419',
+    );
+    expect((gateway as any).client.emit).not.toHaveBeenCalled();
+  });
+  it('should not re-announce auth on link when the wallet is offline', async () => {
+    (gateway as any).authService.findAuthenticatedSessionByRequestId = jest
+      .fn()
+      .mockResolvedValue({
+        sessionId: 'wallet-session-id',
+        wallet: sessionFixtures.authorized.wallet,
+      });
+    // No live socket for the wallet session → not present, must not resolve.
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([]);
+    await gateway.reannounceIfWalletPresent(
+      '019097ff-bb8c-7d5d-9822-7c9eb2c0d419',
+    );
+    expect((gateway as any).client.emit).not.toHaveBeenCalled();
+  });
   it('should re-announce auth when an authenticated wallet reconnects for a requestId', async () => {
     const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
     const session = {
@@ -259,6 +374,7 @@ describe('SignalsGateway', () => {
       request: { session, sessionID: 'wallet-session-id' },
       rooms: new Set(),
       join: jest.fn(),
+      data: {},
     } as unknown as Socket);
     expect((gateway as any).client.emit).toHaveBeenCalledWith('auth', {
       requestId,
@@ -277,6 +393,7 @@ describe('SignalsGateway', () => {
       request: { session, sessionID: 'unauth-session-id' },
       rooms: new Set(),
       join: jest.fn(),
+      data: {},
     } as unknown as Socket);
     expect((gateway as any).client.emit).not.toHaveBeenCalled();
   });

--- a/src/signals/signals.gateway.spec.ts
+++ b/src/signals/signals.gateway.spec.ts
@@ -37,6 +37,7 @@ jest.mock('socket.io', () => {
         emit: jest.fn(),
         in: jest.fn().mockReturnThis(),
         socketsJoin: jest.fn(),
+        fetchSockets: jest.fn().mockResolvedValue([]),
         sockets: {
           adapter: ioAdapterMock,
         },
@@ -53,6 +54,9 @@ describe('SignalsGateway', () => {
     userModel = mongoose.model('User', UserSchema);
     Object.keys(sessionFixtures).forEach((key) => {
       sessionFixtures[key].reload = jest.fn(async (fn) => fn(null));
+      sessionFixtures[key].save = jest.fn();
+      delete sessionFixtures[key].requestId;
+      delete sessionFixtures[key].deviceCount;
     });
 
     const module: TestingModule = await Test.createTestingModule({
@@ -73,6 +77,10 @@ describe('SignalsGateway', () => {
               .mockResolvedValue(sessionFixtures.authorized),
           },
         },
+        {
+          provide: 'ACCOUNT_LINK_SERVICE',
+          useValue: { emit: jest.fn() },
+        },
         SignalsGateway,
       ],
     }).compile();
@@ -92,6 +100,26 @@ describe('SignalsGateway', () => {
     // @ts-expect-error, testing purposes
     expect(gateway.ioAdapter).toBeInstanceOf(Object);
   });
+  it('should join an authenticated session to the requestId room on a global auth event', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([{}, {}]);
+    gateway.afterInit(gateway.server);
+    await linkEventFn(
+      'auth',
+      JSON.stringify({
+        sessionId: 'wallet-session-id',
+        wallet: sessionFixtures.authorized.wallet,
+        requestId,
+      }),
+    );
+    expect(gateway.server.in).toHaveBeenCalledWith('wallet-session-id');
+    expect(gateway.server.socketsJoin).toHaveBeenCalledWith(requestId);
+    expect(gateway.server.emit).toHaveBeenCalledWith('presence', {
+      requestId,
+      deviceCount: 2,
+      online: true,
+    });
+  });
   it('should handle a authenticated connection', async () => {
     await gateway.handleConnection(clientMock);
     expect(clientMock.join).toHaveBeenCalledWith(
@@ -110,9 +138,61 @@ describe('SignalsGateway', () => {
     expect(gateway.logger.debug).toHaveBeenCalled();
   });
   it('should log a disconnect', async () => {
-    gateway.handleDisconnect(clientMock);
+    await gateway.handleDisconnect(clientMock);
     // @ts-expect-error, testing purposes
     expect(gateway.logger.debug).toHaveBeenCalled();
+  });
+  it('should return 0 presence for an empty requestId', async () => {
+    await expect(gateway.updatePresence('')).resolves.toBe(0);
+  });
+  it('should count devices and persist presence to the session', async () => {
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([
+      {},
+      {},
+    ]);
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    const deviceCount = await gateway.updatePresence(
+      requestId,
+      sessionFixtures.authorized as any,
+    );
+    expect(deviceCount).toBe(2);
+    expect(gateway.server.in).toHaveBeenCalledWith(requestId);
+    expect(gateway.server.emit).toHaveBeenCalledWith('presence', {
+      requestId,
+      deviceCount: 2,
+      online: true,
+    });
+    expect((sessionFixtures.authorized as any).requestId).toBe(requestId);
+    expect((sessionFixtures.authorized as any).deviceCount).toBe(2);
+    expect((sessionFixtures.authorized as any).save).toHaveBeenCalled();
+  });
+  it('should refresh presence on disconnect when a requestId is present', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    const session = { requestId, save: jest.fn() };
+    const updatePresenceSpy = jest.spyOn(gateway, 'updatePresence');
+    await gateway.handleDisconnect({
+      request: {
+        session,
+        sessionID: 'authorized-session-id',
+      },
+    } as unknown as Socket);
+    expect(updatePresenceSpy).toHaveBeenCalledWith(requestId, session);
+    expect(session.save).toHaveBeenCalled();
+  });
+  it('should respond to a presence request', async () => {
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([{}, {}]);
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    const result = await gateway.onPresence({ requestId }, clientMock);
+    expect(result).toStrictEqual({
+      requestId,
+      deviceCount: 2,
+      online: true,
+    });
+    expect(gateway.server.emit).toHaveBeenCalledWith('presence', {
+      requestId,
+      deviceCount: 2,
+      online: true,
+    });
   });
   it('should handle a link event', async () => {
     const obs = await gateway.link(
@@ -121,16 +201,25 @@ describe('SignalsGateway', () => {
     );
     obs.subscribe();
 
+    (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([{}, {}]);
     await linkEventFn(
       'auth',
       JSON.stringify({
         data: {
           requestId: '019097ff-bb8c-7d5d-9822-7c9eb2c0d419',
           wallet: sessionFixtures.authorized.wallet,
+          sessionId: 'wallet-session-id',
         },
       }),
     );
     expect((sessionFixtures.authorized as any).reload).toHaveBeenCalled();
+    // Presence: the wallet joins the requestId room and the offer session's
+    // device count is refreshed so /auth/session reflects every device.
+    expect(gateway.server.socketsJoin).toHaveBeenCalledWith(
+      '019097ff-bb8c-7d5d-9822-7c9eb2c0d419',
+    );
+    expect((sessionFixtures.authorized as any).deviceCount).toBe(2);
+    expect((sessionFixtures.authorized as any).save).toHaveBeenCalled();
     expect(globalThis.handleObserver).toBeInstanceOf(Function);
     expect(
       globalThis.handleObserver({ next: jest.fn(), complete: jest.fn() }),
@@ -158,41 +247,74 @@ describe('SignalsGateway', () => {
       },
     });
   });
+  it('should re-announce auth when an authenticated wallet reconnects for a requestId', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    const session = {
+      wallet: sessionFixtures.authorized.wallet,
+      requestId,
+      reload: jest.fn(async (fn: any) => fn(null)),
+      save: jest.fn(),
+    };
+    await gateway.handleConnection({
+      request: { session, sessionID: 'wallet-session-id' },
+      rooms: new Set(),
+      join: jest.fn(),
+    } as unknown as Socket);
+    expect((gateway as any).client.emit).toHaveBeenCalledWith('auth', {
+      requestId,
+      wallet: sessionFixtures.authorized.wallet,
+      sessionId: 'wallet-session-id',
+    });
+  });
+  it('should not re-announce auth for an unauthenticated reconnect', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    const session = {
+      requestId,
+      reload: jest.fn(async (fn: any) => fn(null)),
+      save: jest.fn(),
+    };
+    await gateway.handleConnection({
+      request: { session, sessionID: 'unauth-session-id' },
+      rooms: new Set(),
+      join: jest.fn(),
+    } as unknown as Socket);
+    expect((gateway as any).client.emit).not.toHaveBeenCalled();
+  });
   it('should signal a offer-description', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    (clientMock.request as any).session.requestId = requestId;
     await gateway.onOfferDescription(sdpFixtures.call, clientMock);
-    expect(gateway.server.in).toHaveBeenCalledWith(
-      (clientMock.request as any).session.wallet,
-    );
+    expect(gateway.server.in).toHaveBeenCalledWith(requestId);
     expect(gateway.server.emit).toHaveBeenCalledWith(
       'offer-description',
       sdpFixtures.call,
     );
   });
   it('should signal a offer-candidate', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    (clientMock.request as any).session.requestId = requestId;
     await gateway.onOfferCandidate(candidateFixture, clientMock);
-    expect(gateway.server.in).toHaveBeenCalledWith(
-      (clientMock.request as any).session.wallet,
-    );
+    expect(gateway.server.in).toHaveBeenCalledWith(requestId);
     expect(gateway.server.emit).toHaveBeenCalledWith(
       'offer-candidate',
       candidateFixture,
     );
   });
   it('should signal a answer-description', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    (clientMock.request as any).session.requestId = requestId;
     await gateway.onAnswerDescription(sdpFixtures.answer, clientMock);
-    expect(gateway.server.in).toHaveBeenCalledWith(
-      (clientMock.request as any).session.wallet,
-    );
+    expect(gateway.server.in).toHaveBeenCalledWith(requestId);
     expect(gateway.server.emit).toHaveBeenCalledWith(
       'answer-description',
       sdpFixtures.answer,
     );
   });
   it('should signal a answer-candidate', async () => {
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    (clientMock.request as any).session.requestId = requestId;
     await gateway.onAnswerCandidate(candidateFixture, clientMock);
-    expect(gateway.server.in).toHaveBeenCalledWith(
-      (clientMock.request as any).session.wallet,
-    );
+    expect(gateway.server.in).toHaveBeenCalledWith(requestId);
     expect(gateway.server.emit).toHaveBeenCalledWith(
       'answer-candidate',
       candidateFixture,

--- a/src/signals/signals.gateway.spec.ts
+++ b/src/signals/signals.gateway.spec.ts
@@ -277,12 +277,14 @@ describe('SignalsGateway', () => {
   });
   it('should re-announce auth on link when a wallet is genuinely present', async () => {
     const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
-    (gateway as any).authService.findAuthenticatedSessionByRequestId = jest
+    (gateway as any).authService.findAuthenticatedSessionsByRequestId = jest
       .fn()
-      .mockResolvedValue({
-        sessionId: 'wallet-session-id',
-        wallet: sessionFixtures.authorized.wallet,
-      });
+      .mockResolvedValue([
+        {
+          sessionId: 'wallet-session-id',
+          wallet: sessionFixtures.authorized.wallet,
+        },
+      ]);
     // The wallet's own session still owns a live socket → genuinely present.
     (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([{}]);
     await gateway.reannounceIfWalletPresent(requestId);
@@ -291,6 +293,38 @@ describe('SignalsGateway', () => {
       requestId,
       wallet: sessionFixtures.authorized.wallet,
       sessionId: 'wallet-session-id',
+    });
+  });
+  it('should skip a stale wallet session and re-announce the live one', async () => {
+    // Repeated restarts leave several sessions carrying the same requestId +
+    // wallet; only the last owns a live socket. The re-announce must skip the
+    // dead one(s) instead of bailing on the first match, otherwise the linking
+    // peer's `auth` never fires and its `link` hangs forever.
+    const requestId = '019097ff-bb8c-7d5d-9822-7c9eb2c0d419';
+    (gateway as any).authService.findAuthenticatedSessionsByRequestId = jest
+      .fn()
+      .mockResolvedValue([
+        {
+          sessionId: 'stale-session-id',
+          wallet: sessionFixtures.authorized.wallet,
+        },
+        {
+          sessionId: 'live-session-id',
+          wallet: sessionFixtures.authorized.wallet,
+        },
+      ]);
+    // First candidate has no live socket (stale), second is genuinely present.
+    (gateway.server.fetchSockets as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{}]);
+    await gateway.reannounceIfWalletPresent(requestId);
+    expect(gateway.server.in).toHaveBeenCalledWith('stale-session-id');
+    expect(gateway.server.in).toHaveBeenCalledWith('live-session-id');
+    expect((gateway as any).client.emit).toHaveBeenCalledTimes(1);
+    expect((gateway as any).client.emit).toHaveBeenCalledWith('auth', {
+      requestId,
+      wallet: sessionFixtures.authorized.wallet,
+      sessionId: 'live-session-id',
     });
   });
   it('should kick out stale sessions bound to the same credential', async () => {
@@ -340,21 +374,23 @@ describe('SignalsGateway', () => {
     expect(evictSpy).not.toHaveBeenCalled();
   });
   it('should not re-announce auth on link when no wallet session exists', async () => {
-    (gateway as any).authService.findAuthenticatedSessionByRequestId = jest
+    (gateway as any).authService.findAuthenticatedSessionsByRequestId = jest
       .fn()
-      .mockResolvedValue(null);
+      .mockResolvedValue([]);
     await gateway.reannounceIfWalletPresent(
       '019097ff-bb8c-7d5d-9822-7c9eb2c0d419',
     );
     expect((gateway as any).client.emit).not.toHaveBeenCalled();
   });
   it('should not re-announce auth on link when the wallet is offline', async () => {
-    (gateway as any).authService.findAuthenticatedSessionByRequestId = jest
+    (gateway as any).authService.findAuthenticatedSessionsByRequestId = jest
       .fn()
-      .mockResolvedValue({
-        sessionId: 'wallet-session-id',
-        wallet: sessionFixtures.authorized.wallet,
-      });
+      .mockResolvedValue([
+        {
+          sessionId: 'wallet-session-id',
+          wallet: sessionFixtures.authorized.wallet,
+        },
+      ]);
     // No live socket for the wallet session → not present, must not resolve.
     (gateway.server.fetchSockets as jest.Mock).mockResolvedValueOnce([]);
     await gateway.reannounceIfWalletPresent(

--- a/src/signals/signals.gateway.ts
+++ b/src/signals/signals.gateway.ts
@@ -75,6 +75,19 @@ export class SignalsGateway
               server.in(data.sessionId).socketsJoin(data.requestId);
               await this.updatePresence(data.requestId);
             }
+            // Device deduplication: a credential (`credId`) can only ever
+            // belong to a single device, so any other session carrying the same
+            // credId is a stale login from that same device (e.g. a legacy
+            // application that re-authenticates on every connection, or a wallet
+            // that logs in again). Kick those out so the device is always
+            // counted once — other devices that merely share the wallet address
+            // are left alone (a wallet key may live on many devices).
+            if (typeof data.credId === 'string' && data.credId.length > 0) {
+              await this.evictDuplicateCredentialSessions(
+                data.credId,
+                data.sessionId,
+              );
+            }
           }
         } catch (e) {
           this.logger.error('Failed to handle global auth message', e);
@@ -102,6 +115,11 @@ export class SignalsGateway
     );
     if (typeof request.sessionID === 'string') {
       await socket.join(request.sessionID);
+      // Stamp the session id onto the socket so presence counting can collapse
+      // multiple sockets belonging to the same device (session) into a single
+      // device. socket.data is propagated across nodes by the Redis adapter, so
+      // it is available on the RemoteSockets returned by fetchSockets.
+      socket.data.sessionId = request.sessionID;
     }
     if (
       typeof session.wallet === 'string' &&
@@ -155,11 +173,15 @@ export class SignalsGateway
   /**
    * Count Devices
    *
-   * Counts how many sockets (devices) are currently connected for a given
-   * requestId room. Works across nodes via the Redis adapter's fetchSockets.
-   * This is the live source of truth for presence, so callers (e.g.
-   * /auth/session) can check the count on demand instead of relying on a
-   * value persisted at an earlier, possibly racy, moment.
+   * Counts how many distinct devices are currently connected for a given
+   * requestId room. Devices are identified by their session id (not by raw
+   * socket) so that a single device is only ever counted once even if it owns
+   * several sockets in the room (e.g. a lingering socket from a previous
+   * connection plus a freshly reconnected one). Works across nodes via the
+   * Redis adapter's fetchSockets. This is the live source of truth for
+   * presence, so callers (e.g. /auth/session) can check the count on demand
+   * instead of relying on a value persisted at an earlier, possibly racy,
+   * moment.
    *
    * @param requestId - The request identifier peers are connecting for
    * @returns The number of connected devices for the requestId
@@ -169,7 +191,24 @@ export class SignalsGateway
       return 0;
     }
     const sockets = await this.server.in(requestId).fetchSockets();
-    return sockets.length;
+    // Count distinct devices, not raw sockets. A single device (session) may
+    // briefly own more than one socket in the room — e.g. when it reconnects
+    // and its previous socket has not been cleaned up yet, or when the socket
+    // service closes and reopens — and each socket would otherwise inflate the
+    // count, making the same device look like a new one on every reconnect.
+    // Since one session is always the same device, collapse the sockets by
+    // their session id (stamped in handleConnection) so a device is only ever
+    // counted once no matter how it reconnects. Sockets missing a session id
+    // fall back to their own id so they are still counted individually.
+    const devices = new Set<string>();
+    for (const socket of sockets) {
+      const sessionId =
+        socket.data && typeof socket.data.sessionId === 'string'
+          ? socket.data.sessionId
+          : socket.id;
+      devices.add(sessionId);
+    }
+    return devices.size;
   }
 
   /**
@@ -208,6 +247,104 @@ export class SignalsGateway
       session.save();
     }
     return deviceCount;
+  }
+
+  /**
+   * Evict stale sessions bound to the same credential
+   *
+   * A credential (`credId`) can only ever belong to a single device. When a
+   * device authenticates (attestation or assertion — see the global `auth`
+   * handler) any previously stored session carrying the same credId is a stale
+   * login from that same device, so its sockets are disconnected: they
+   * immediately stop counting toward presence for whatever request they were
+   * connected to. This keeps a device — including a legacy application that
+   * re-authenticates on every connection — counted once instead of accumulating
+   * a new device on every login/link. Sessions that merely share the wallet
+   * address (a different device the user owns) are left untouched.
+   *
+   * @param credId - The credential id that identifies the device to deduplicate
+   * @param keepSessionId - The freshly authenticated session to keep
+   */
+  async evictDuplicateCredentialSessions(
+    credId: string,
+    keepSessionId?: string,
+  ): Promise<void> {
+    if (typeof credId !== 'string' || credId.length === 0) {
+      return;
+    }
+    try {
+      const staleSessions = await this.authService.findSessionsByCredId(
+        credId,
+        keepSessionId,
+      );
+      for (const sessionId of staleSessions) {
+        this.logger.debug(
+          `(*) Evicting stale session ${sessionId} for credential ${credId}`,
+        );
+        // Disconnect the stale session's sockets so it stops counting toward
+        // presence for any request it was connected to.
+        const sockets = await this.server.in(sessionId).fetchSockets();
+        for (const socket of sockets) {
+          socket.disconnect(true);
+        }
+      }
+    } catch (e) {
+      this.logger.error('Failed to evict stale credential sessions', e);
+    }
+  }
+
+  /**
+   * Re-announce Auth for a genuinely present wallet
+   *
+   * When a peer links for a requestId that a wallet has ALREADY authenticated
+   * for and is currently connected to (a live socket in the requestId room),
+   * re-announce that wallet's `auth`. This drives an order-independent pairing
+   * rendezvous: the wallet only broadcasts `auth` once on connect, so a peer
+   * that links afterwards would otherwise never learn the wallet is present.
+   *
+   * The re-announce is strictly gated on LIVE presence — it verifies the
+   * wallet's own session still has a connected socket — so a link never
+   * resolves against a wallet that has gone offline.
+   *
+   * @param requestId - The request identifier peers are connecting for
+   * @param excludeSessionId - The linking peer's own session, ignored so the
+   *   match identifies the OTHER party (the wallet) rather than the caller
+   */
+  async reannounceIfWalletPresent(
+    requestId: string,
+    excludeSessionId?: string,
+  ): Promise<void> {
+    if (typeof requestId !== 'string' || requestId.length === 0) {
+      return;
+    }
+    try {
+      const authed = await this.authService.findAuthenticatedSessionByRequestId(
+        requestId,
+        excludeSessionId,
+      );
+      if (!authed) {
+        return;
+      }
+      // Confirm the wallet is genuinely online right now: its session must
+      // still own a connected socket. Without this a stale (persisted) session
+      // would resolve a link for a wallet that is no longer available.
+      const walletSockets = await this.server
+        .in(authed.sessionId)
+        .fetchSockets();
+      if (walletSockets.length === 0) {
+        return;
+      }
+      this.logger.debug(
+        `(link): wallet ${authed.wallet} already present for RequestId: ${requestId}; re-announcing auth`,
+      );
+      this.client.emit<string>('auth', {
+        requestId,
+        wallet: authed.wallet,
+        sessionId: authed.sessionId,
+      });
+    } catch (e) {
+      this.logger.error('Failed to re-announce auth for present wallet', e);
+    }
   }
 
   /**
@@ -266,9 +403,7 @@ export class SignalsGateway
                 body.requestId.length > 0
               ) {
                 if (typeof data.sessionId === 'string') {
-                  this.server
-                    .in(data.sessionId)
-                    .socketsJoin(body.requestId);
+                  this.server.in(data.sessionId).socketsJoin(body.requestId);
                 }
                 await this.updatePresence(body.requestId, request.session);
               }
@@ -283,6 +418,19 @@ export class SignalsGateway
         };
 
         this.ioAdapter.subClient.on('message', handleAuthMessage);
+
+        // Order-independent rendezvous: the wallet re-announces `auth` once when
+        // its socket connects (see handleConnection). A peer that links AFTER
+        // the wallet is already connected would miss that one-shot announce and
+        // wait forever — its `once(offer-description)` never arms, so every
+        // offer the wallet sends is dropped and negotiation times out. Now that
+        // this peer's auth listener is armed, re-announce `auth` if the wallet
+        // is genuinely present (a live socket) for this requestId, so the link
+        // resolves regardless of which side connected first. Gated on live
+        // presence, so a link never resolves against an offline wallet. The
+        // caller's own session is excluded so we detect the OTHER party (both
+        // peers share the same wallet + requestId after a first pairing).
+        void this.reannounceIfWalletPresent(body.requestId, request.sessionID);
 
         return () => {
           this.ioAdapter.subClient.off('message', handleAuthMessage);
@@ -311,8 +459,15 @@ export class SignalsGateway
    * On Presence request, report how many devices are connected for a requestId.
    *
    * A (potentially offline) client can query this to detect whether there is
-   * anyone available to connect to before attempting to reconnect. The current
-   * presence is also persisted to the requesting user's session information.
+   * anyone available to connect to before attempting to reconnect.
+   *
+   * This is a pure read: it must NOT persist the requestId onto the querying
+   * client's session. Persisting it here would cause that client to auto-join
+   * the requestId room on its next (re)connect (see handleConnection), so it
+   * would be counted as a connected device even though it never linked and is
+   * not armed to receive a connection. Presence membership is only established
+   * by actually waiting for a connection (link) or negotiating, so we count and
+   * broadcast without touching the caller's session.
    *
    * @param body
    * @param client
@@ -326,10 +481,7 @@ export class SignalsGateway
     this.logger.debug(
       `(presence): request for Session: ${request.sessionID} with RequestId: ${body.requestId}`,
     );
-    const deviceCount = await this.updatePresence(
-      body.requestId,
-      request.session,
-    );
+    const deviceCount = await this.updatePresence(body.requestId);
     return {
       requestId: body.requestId,
       deviceCount,

--- a/src/signals/signals.gateway.ts
+++ b/src/signals/signals.gateway.ts
@@ -8,7 +8,8 @@ import {
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
-import { Logger } from '@nestjs/common';
+import { Inject, Logger } from '@nestjs/common';
+import { ClientProxy } from '@nestjs/microservices';
 import type { Server, Socket } from 'socket.io';
 import { Session as SessionType } from 'express-session';
 import { Observable, Subscriber } from 'rxjs';
@@ -39,7 +40,10 @@ export class SignalsGateway
   server: Server;
   private ioAdapter: RedisIoAdapter;
   private readonly logger = new Logger(SignalsGateway.name);
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    @Inject('ACCOUNT_LINK_SERVICE') private client: ClientProxy,
+  ) {}
   /**
    * Initialize the Gateway
    *
@@ -50,7 +54,7 @@ export class SignalsGateway
   afterInit(server: Server) {
     this.ioAdapter = server.sockets.adapter as unknown as RedisIoAdapter;
     this.ioAdapter.subClient.subscribe('auth');
-    this.ioAdapter.subClient.on('message', (channel, message) => {
+    this.ioAdapter.subClient.on('message', async (channel, message) => {
       if (channel === 'auth') {
         try {
           const parsed = JSON.parse(message);
@@ -60,6 +64,17 @@ export class SignalsGateway
               `(*) Global Auth Event: Joining Sockets for Session ${data.sessionId} to Room ${data.wallet}`,
             );
             server.in(data.sessionId).socketsJoin(data.wallet);
+            // Presence: the authenticated device (e.g. a wallet) connects for a
+            // requestId but above only joins its wallet room. Join it to the
+            // requestId room as well so it is counted as a connected device and
+            // refresh presence so peers see every device.
+            if (
+              typeof data.requestId === 'string' &&
+              data.requestId.length > 0
+            ) {
+              server.in(data.sessionId).socketsJoin(data.requestId);
+              await this.updatePresence(data.requestId);
+            }
           }
         } catch (e) {
           this.logger.error('Failed to handle global auth message', e);
@@ -97,13 +112,102 @@ export class SignalsGateway
       );
       await socket.join(session.wallet);
     }
+    // Presence: if this session is already tied to a request, re-join the
+    // request room and refresh how many devices are connected for it.
+    if (typeof session.requestId === 'string' && session.requestId.length > 0) {
+      if (!socket.rooms.has(session.requestId)) {
+        await socket.join(session.requestId);
+      }
+      await this.updatePresence(session.requestId, request.session);
+      // Presence-driven renegotiation: an already-authenticated device (it has
+      // a wallet) that reconnects for a known requestId re-announces `auth`.
+      // This is genuine presence — the device is actually online — so a peer
+      // whose `link` is waiting for this requestId resolves and they can
+      // renegotiate the session over the socket, with no new passkey assertion.
+      // First-time handshakes (no wallet yet) still wait for the real auth
+      // event, so `link` always waits as expected.
+      if (typeof session.wallet === 'string' && session.wallet.length > 0) {
+        this.logger.debug(
+          `(*) Re-announcing auth for reconnected wallet ${session.wallet} on RequestId: ${session.requestId}`,
+        );
+        this.client.emit<string>('auth', {
+          requestId: session.requestId,
+          wallet: session.wallet,
+          sessionId: request.sessionID,
+        });
+      }
+    }
   }
 
-  handleDisconnect(socket: Socket) {
+  async handleDisconnect(socket: Socket) {
     const request = socket.request as Record<string, any>;
     this.logger.debug(
       `(*) Client Disconnected with Session: ${request.sessionID}`,
     );
+    const session = request.session as Record<string, any>;
+    // Presence: refresh the connected device count when a peer leaves so the
+    // remaining peers know whether anyone is still available to connect to.
+    if (session && typeof session.requestId === 'string') {
+      await this.updatePresence(session.requestId, request.session);
+    }
+  }
+
+  /**
+   * Count Devices
+   *
+   * Counts how many sockets (devices) are currently connected for a given
+   * requestId room. Works across nodes via the Redis adapter's fetchSockets.
+   * This is the live source of truth for presence, so callers (e.g.
+   * /auth/session) can check the count on demand instead of relying on a
+   * value persisted at an earlier, possibly racy, moment.
+   *
+   * @param requestId - The request identifier peers are connecting for
+   * @returns The number of connected devices for the requestId
+   */
+  async countDevices(requestId: string): Promise<number> {
+    if (typeof requestId !== 'string' || requestId.length === 0) {
+      return 0;
+    }
+    const sockets = await this.server.in(requestId).fetchSockets();
+    return sockets.length;
+  }
+
+  /**
+   * Update Presence
+   *
+   * Counts the connected devices for a given requestId room and notifies
+   * everyone connected for that request. When a session is provided the
+   * presence information is persisted to the user's session so it can be
+   * displayed in their session information and used to decide whether an
+   * offline client should attempt to reconnect.
+   *
+   * @param requestId - The request identifier peers are connecting for
+   * @param session - Optional Express session to persist presence to
+   */
+  async updatePresence(
+    requestId: string,
+    session?: SessionType & Record<string, any>,
+  ): Promise<number> {
+    if (typeof requestId !== 'string' || requestId.length === 0) {
+      return 0;
+    }
+    const deviceCount = await this.countDevices(requestId);
+    this.logger.debug(
+      `(presence): ${deviceCount} device(s) connected for RequestId: ${requestId}`,
+    );
+    // Notify everyone connected for this request of the current presence
+    this.server.in(requestId).emit('presence', {
+      requestId,
+      deviceCount,
+      online: deviceCount > 0,
+    });
+    // Persist presence to the user's session information when provided
+    if (session) {
+      session.requestId = requestId;
+      session.deviceCount = deviceCount;
+      session.save();
+    }
+    return deviceCount;
   }
 
   /**
@@ -123,6 +227,14 @@ export class SignalsGateway
     // Find the stored session
     const session = await this.authService.findSession(request.sessionID);
     if (session) {
+      // Presence: join a room scoped to the requestId so we can track how
+      // many devices are connected for this connection request.
+      if (typeof body.requestId === 'string' && body.requestId.length > 0) {
+        if (!client.rooms.has(body.requestId)) {
+          await client.join(body.requestId);
+        }
+        await this.updatePresence(body.requestId, request.session);
+      }
       await this.ioAdapter.subClient.subscribe('auth');
       const handleObserver = (observer: Subscriber<any>) => {
         const handleAuthMessage = async (
@@ -145,6 +257,21 @@ export class SignalsGateway
                 `(*) Joining Room: ${data.wallet} with Session: ${request.sessionID}`,
               );
               await client.join(data.wallet);
+              // Presence: the wallet has authenticated for this request. Make
+              // sure its sockets join the requestId room too, then recount and
+              // persist presence to this (offer) session so every connected
+              // device is reflected in its session information (/auth/session).
+              if (
+                typeof body.requestId === 'string' &&
+                body.requestId.length > 0
+              ) {
+                if (typeof data.sessionId === 'string') {
+                  this.server
+                    .in(data.sessionId)
+                    .socketsJoin(body.requestId);
+                }
+                await this.updatePresence(body.requestId, request.session);
+              }
               this.ioAdapter.subClient.off('message', handleAuthMessage);
               observer.next(data);
               observer.complete();
@@ -179,6 +306,37 @@ export class SignalsGateway
       return obs$.pipe(map(handleObserverMap));
     }
   }
+
+  /**
+   * On Presence request, report how many devices are connected for a requestId.
+   *
+   * A (potentially offline) client can query this to detect whether there is
+   * anyone available to connect to before attempting to reconnect. The current
+   * presence is also persisted to the requesting user's session information.
+   *
+   * @param body
+   * @param client
+   */
+  @SubscribeMessage('presence')
+  async onPresence(
+    @MessageBody() body: { requestId: string },
+    @ConnectedSocket() client: Socket,
+  ): Promise<{ requestId: string; deviceCount: number; online: boolean }> {
+    const request = client.request as Record<string, any>;
+    this.logger.debug(
+      `(presence): request for Session: ${request.sessionID} with RequestId: ${body.requestId}`,
+    );
+    const deviceCount = await this.updatePresence(
+      body.requestId,
+      request.session,
+    );
+    return {
+      requestId: body.requestId,
+      deviceCount,
+      online: deviceCount > 0,
+    };
+  }
+
   @SubscribeMessage('offer-candidate')
   async onOfferCandidate(
     @MessageBody()
@@ -189,8 +347,14 @@ export class SignalsGateway
     const request = client.request as Record<string, any>;
     await reloadSession(request.session);
     const session = request.session as Session & Record<string, any>;
-    if (typeof session.wallet === 'string') {
-      this.server.in(session.wallet).emit('offer-candidate', data);
+    // Signaling is scoped to the requestId room (the identifier that names the
+    // pairing and drives presence) rather than the wallet address, so SDP/ICE
+    // flows between the two peers without depending on the wallet identity.
+    if (typeof session.requestId === 'string') {
+      if (!client.rooms.has(session.requestId)) {
+        client.join(session.requestId);
+      }
+      this.server.in(session.requestId).emit('offer-candidate', data);
     }
   }
 
@@ -205,12 +369,12 @@ export class SignalsGateway
     await reloadSession(request.session);
     const session = request.session as Record<string, any>;
 
-    if (typeof session.wallet === 'string') {
-      if (!client.rooms.has(session.wallet)) {
-        client.join(session.wallet);
+    if (typeof session.requestId === 'string') {
+      if (!client.rooms.has(session.requestId)) {
+        client.join(session.requestId);
       }
-      // Send description to all clients in the public key's room
-      this.server.in(session.wallet).emit('offer-description', data);
+      // Send description to all clients in the requestId room
+      this.server.in(session.requestId).emit('offer-description', data);
     }
   }
   @SubscribeMessage('answer-description')
@@ -223,11 +387,11 @@ export class SignalsGateway
     await reloadSession(request.session);
 
     const session = request.session as Record<string, any>;
-    if (typeof session.wallet === 'string') {
-      if (!client.rooms.has(session.wallet)) {
-        client.join(session.wallet);
+    if (typeof session.requestId === 'string') {
+      if (!client.rooms.has(session.requestId)) {
+        client.join(session.requestId);
       }
-      this.server.in(session.wallet).emit('answer-description', data);
+      this.server.in(session.requestId).emit('answer-description', data);
     }
   }
   @SubscribeMessage('answer-candidate')
@@ -241,12 +405,12 @@ export class SignalsGateway
     await reloadSession(request.session);
 
     const session = request.session as Record<string, any>;
-    if (typeof session.wallet === 'string') {
-      if (!client.rooms.has(session.wallet)) {
-        client.join(session.wallet);
+    if (typeof session.requestId === 'string') {
+      if (!client.rooms.has(session.requestId)) {
+        client.join(session.requestId);
       }
       this.logger.debug(`Sending (answer-candidate): ${JSON.stringify(data)}`);
-      this.server.in(session.wallet).emit('answer-candidate', data);
+      this.server.in(session.requestId).emit('answer-candidate', data);
     }
   }
 }

--- a/src/signals/signals.gateway.ts
+++ b/src/signals/signals.gateway.ts
@@ -302,13 +302,16 @@ export class SignalsGateway
    * rendezvous: the wallet only broadcasts `auth` once on connect, so a peer
    * that links afterwards would otherwise never learn the wallet is present.
    *
-   * The re-announce is strictly gated on LIVE presence — it verifies the
-   * wallet's own session still has a connected socket — so a link never
-   * resolves against a wallet that has gone offline.
+   * The re-announce is strictly gated on LIVE presence — it verifies a
+   * candidate wallet session still has a connected socket — so a link never
+   * resolves against a wallet that has gone offline. All authenticated
+   * sessions for the requestId are considered (not just the first stored one),
+   * so an accumulated stale/dead duplicate can never shadow the one wallet
+   * session that is genuinely present.
    *
    * @param requestId - The request identifier peers are connecting for
    * @param excludeSessionId - The linking peer's own session, ignored so the
-   *   match identifies the OTHER party (the wallet) rather than the caller
+   *   matches identify the OTHER party (the wallet) rather than the caller
    */
   async reannounceIfWalletPresent(
     requestId: string,
@@ -318,30 +321,40 @@ export class SignalsGateway
       return;
     }
     try {
-      const authed = await this.authService.findAuthenticatedSessionByRequestId(
-        requestId,
-        excludeSessionId,
-      );
-      if (!authed) {
+      // Scan EVERY authenticated session for this requestId, not just the
+      // first: repeated peer/app restarts accumulate several sessions carrying
+      // the same requestId + wallet, and typically only one still owns a live
+      // socket. Picking only the first match and bailing when it has no socket
+      // (the previous behaviour) let a stale/dead session shadow the genuinely
+      // present wallet, so the linking peer's `auth` never fired and its `link`
+      // hung forever — the peer sat "waiting to pair" while presence showed the
+      // wallet online. Re-announce the FIRST candidate that is actually present.
+      const candidates =
+        await this.authService.findAuthenticatedSessionsByRequestId(
+          requestId,
+          excludeSessionId,
+        );
+      for (const authed of candidates) {
+        // Confirm the wallet is genuinely online right now: its session must
+        // still own a connected socket. Without this a stale (persisted)
+        // session would resolve a link for a wallet that is no longer
+        // available.
+        const walletSockets = await this.server
+          .in(authed.sessionId)
+          .fetchSockets();
+        if (walletSockets.length === 0) {
+          continue;
+        }
+        this.logger.debug(
+          `(link): wallet ${authed.wallet} already present for RequestId: ${requestId}; re-announcing auth`,
+        );
+        this.client.emit<string>('auth', {
+          requestId,
+          wallet: authed.wallet,
+          sessionId: authed.sessionId,
+        });
         return;
       }
-      // Confirm the wallet is genuinely online right now: its session must
-      // still own a connected socket. Without this a stale (persisted) session
-      // would resolve a link for a wallet that is no longer available.
-      const walletSockets = await this.server
-        .in(authed.sessionId)
-        .fetchSockets();
-      if (walletSockets.length === 0) {
-        return;
-      }
-      this.logger.debug(
-        `(link): wallet ${authed.wallet} already present for RequestId: ${requestId}; re-announcing auth`,
-      );
-      this.client.emit<string>('auth', {
-        requestId,
-        wallet: authed.wallet,
-        sessionId: authed.sessionId,
-      });
     } catch (e) {
       this.logger.error('Failed to re-announce auth for present wallet', e);
     }

--- a/src/signals/signals.module.ts
+++ b/src/signals/signals.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { SignalsGateway } from './signals.gateway.js';
 import { MongooseModule } from '@nestjs/mongoose';
+import { ClientsModule, Transport } from '@nestjs/microservices';
 import { Session, SessionSchema } from '../auth/session.schema.js';
 import { User, UserSchema } from '../auth/auth.schema.js';
 import { AuthService } from '../auth/auth.service.js';
@@ -11,7 +12,23 @@ import { AuthService } from '../auth/auth.service.js';
       { name: Session.name, schema: SessionSchema },
       { name: User.name, schema: UserSchema },
     ]),
+    // Presence-driven renegotiation: the gateway re-announces `auth` over this
+    // client when an authenticated wallet reconnects, so a peer whose `link` is
+    // waiting for the requestId can resume the session without a new passkey.
+    ClientsModule.register([
+      {
+        name: 'ACCOUNT_LINK_SERVICE',
+        transport: Transport.REDIS,
+        options: {
+          host: process.env.REDIS_HOST || 'localhost',
+          port: parseInt(process.env.REDIS_PORT, 10) || 6379,
+          username: process.env.REDIS_USERNAME || 'default',
+          password: process.env.REDIS_PASSWORD || '',
+        },
+      },
+    ]),
   ],
   providers: [AuthService, SignalsGateway],
+  exports: [SignalsGateway],
 })
 export class SignalsModule {}

--- a/src/views/index.hbs
+++ b/src/views/index.hbs
@@ -249,6 +249,41 @@
       .presence.offline {
           color: #ff4444;
       }
+      .connecting {
+          max-width: 600px;
+          margin: 0 auto;
+          background: #1a1a1a;
+          border-radius: 12px;
+          padding: 20px;
+          box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+          text-align: left;
+      }
+      .connecting h1 {
+          font-size: 1.5em;
+          margin: 0 0 10px;
+          text-align: center;
+      }
+      .debug-log {
+          list-style: none;
+          margin: 12px 0 0;
+          padding: 10px;
+          background: #242424;
+          border: 1px solid #333;
+          border-radius: 8px;
+          max-height: 200px;
+          overflow-y: auto;
+          font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+          font-size: 0.8em;
+          color: #aaa;
+      }
+      .debug-log li {
+          padding: 2px 0;
+          border-bottom: 1px solid #2c2c2c;
+          word-break: break-all;
+      }
+      .debug-log li:last-child {
+          border-bottom: none;
+      }
       .status-bar {
           display: flex;
           flex-wrap: wrap;
@@ -273,6 +308,30 @@
       .status-bar .status-pill.agent-active {
           border-color: #4CAF50;
           color: #4CAF50;
+      }
+      .thread-bar {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+          align-items: center;
+          font-size: 0.85em;
+          color: #aaa;
+          padding: 4px 10px;
+      }
+      .thread-bar label {
+          color: #aaa;
+      }
+      .thread-bar select {
+          flex: 1 1 auto;
+          min-width: 120px;
+          background: #242424;
+          border: 1px solid #333;
+          border-radius: 8px;
+          color: inherit;
+          padding: 4px 8px;
+      }
+      .thread-bar button {
+          padding: 4px 12px;
       }
       @media (prefers-color-scheme: light) {
           :root {
@@ -382,8 +441,12 @@
  window.addEventListener("load", ()=>{
 
 
-       // The Signaling Client
-       const client = new SignalClient(window.origin)
+       // The Signaling Client. Construct with `autoConnect: false` so simply
+       // opening the debug app (the main menu) does NOT open a socket to the
+       // signaling service. The connection is established lazily the first time
+       // the user takes an action that needs it — clicking Start (offer), Sign
+       // In (answer), or Check Presence — via `ensureSocketConnected()`.
+       const client = new SignalClient(window.origin, { autoConnect: false })
        // WebRTC Configuration
        const RTC_CONFIGURATION = {
          iceServers: [
@@ -409,14 +472,21 @@
          ],
          iceCandidatePoolSize: 10,
        }
-       // RequestId for this client. Use a generated UUID as the basis, but
-       // persist it and allow editing so the same id can be reused across
-       // reloads to exercise reconnect/reuse against a wallet that remembers it.
-       // `forgetRequestId()` clears the saved id and mints a fresh one, mirroring
-       // the open-claw reference plugin's `ac2 forget`.
+       // RequestId for this client. Use a generated UUID as the basis, but allow
+       // editing so the same id can be reused across reloads to exercise
+       // reconnect/reuse against a wallet that remembers it.
+       //
+       // We only PERSIST a requestId once it has actually connected (see
+       // `saveConnectedRequestId`, called from `routeChannel`). A freshly minted
+       // or edited id stays in memory until it reaches a live connection, so the
+       // debug app never "remembers" an id that never paired. Mirroring that,
+       // `forgetRequestId()` only forgets an id that has connected.
        const REQUEST_ID_STORAGE_KEY = 'liquid_request_id'
        let requestId = localStorage.getItem(REQUEST_ID_STORAGE_KEY) || SignalClient.generateRequestId()
-       localStorage.setItem(REQUEST_ID_STORAGE_KEY, requestId)
+       // Whether the current requestId has reached a live p2p connection. A
+       // stored id means it connected on a previous run, so seed the flag from
+       // storage. Drives implicit save-on-connect and gates the Forget button.
+       let hasConnected = !!localStorage.getItem(REQUEST_ID_STORAGE_KEY)
        // RequestId for a remote client
        let altRequestId = requestId
        // Globals for connection management
@@ -434,12 +504,44 @@
        // STX (0x02) prefix for `ac2-stream` control frames (matches the wallet
        // and the open-claw reference plugin's stream protocol).
        const AC2_STREAM_CONTROL_PREFIX = '\u0002';
-       // Thread id last seen from the wallet/agent; used when replaying history
-       // back to the wallet. Defaults to the plugin's default thread.
-       let currentThid = 'default';
+       // Conversation threads for AC2. The debug app plays the agent/plugin
+       // side, and a single connection can carry multiple conversations, each
+       // keyed by a thread id (`thid`). We keep a per-thread message store so
+       // several conversations can be tested at once and switched between in the
+       // chat header. `'default'` matches the plugin/wallet default thread.
+       const DEFAULT_THID = 'default';
+       // The conversation currently shown in the chat window.
+       let activeThid = DEFAULT_THID;
+       // thid -> { title, messages: [{ text, sender }], unread }. Loaded per
+       // connected address and persisted to `threads_<address>` in localStorage.
+       let threads = Object.create(null);
+       // Whether the thread store has been loaded for the current connection.
+       // Loaded once (in `routeChannel`) before any channel delivers a message so
+       // inbound frames aren't clobbered by a later load. Reset on disconnect.
+       let threadsReady = false;
        // Live "still streaming" preview bubble for the agent's `ac2-stream`
        // preview frames; committed as a normal message on `finalize`.
        let streamPreviewEl = null;
+       // The outstanding offer `link-message` listener while the offer client is
+       // awaiting a peer to link (QR shown). Tracked so a manual Disconnect can
+       // detach it and stop the link await instead of leaving a stale handler
+       // that a later peer link could fire.
+       let offerLinkHandler = null;
+       // True while a user-initiated (manual) disconnect is tearing things down.
+       // Closing `client.peerClient` fires the data channel's `onclose`/`onerror`
+       // asynchronously, which would otherwise call `resetConnection(...)` with a
+       // non-manual reason and re-show the QR + re-await a link (the "disconnect
+       // then immediately reconnects" bug). This flag lets those handlers no-op
+       // during a deliberate disconnect; it is cleared when a new connection is
+       // started (Start / Sign In).
+       let deliberateDisconnect = false;
+       // True once a peer has actually linked to the offer client (we entered the
+       // connecting/negotiating or chat state). Used so a `presence` broadcast
+       // showing the peer has left (deviceCount <= 1) can immediately return us to
+       // the QR/awaiting-link state instead of waiting out the slow data-channel
+       // `onclose` / ICE timeout. Not armed while merely awaiting a first link (so
+       // our own single-device presence never triggers a spurious reset).
+       let peerLinked = false;
 
        // Render the UI
        const app = document.querySelector('#app');
@@ -458,7 +560,8 @@
                <p id="offer-presence" class="presence"></p>
                <button id="start" onclick="handleOfferClient()">Start</button>
                <button id="toggle" onclick="toggle()">Switch</button>
-               <button class="danger" onclick="forgetRequestId()">Forget</button>
+               <button id="forget" class="danger ${hasConnected ? '' : 'hidden'}" onclick="forgetRequestId()">Forget</button>
+               <button id="offer-cancel" class="danger hidden" onclick="resetConnection('manual')">Cancel</button>
            </div>
            <div class="answer hidden">
                <h1>Answer Client</h1>
@@ -467,6 +570,14 @@
                <button id="check-presence" onclick="checkPresence()">Check Presence</button>
                <button id="attestation" onclick="handleSignChallenge()">Sign In</button>
                <p id="answer-presence" class="presence"></p>
+           </div>
+       </div>
+       <div class="connecting hidden">
+           <h1>Linking…</h1>
+           <p id="connecting-info" class="presence"></p>
+           <ul id="connecting-log" class="debug-log"></ul>
+           <div class="controls">
+               <button class="danger" onclick="resetConnection('manual')">Cancel</button>
            </div>
        </div>
        <div class="message-container hidden">
@@ -480,6 +591,11 @@
                    <button class="danger" onclick="clearHistory()">Clear History</button>
                    <button class="danger" onclick="resetConnection('manual')">Disconnect</button>
                </div>
+           </div>
+           <div class="thread-bar">
+               <label for="thread-select">Thread:</label>
+               <select id="thread-select" onchange="switchThread()"></select>
+               <button onclick="newThread()">New</button>
            </div>
            <div class="status-bar">
                <span class="status-pill" id="connection-status">Connecting…</span>
@@ -524,6 +640,9 @@
         */
        function checkPresence(id) {
          const targetId = typeof id === 'string' ? id : altRequestId;
+         // A presence check needs the socket; connect it on demand (the main
+         // menu stays offline until an action like this).
+         ensureSocketConnected();
          whenSocketReady((socket) => {
            socket.emit('presence', { requestId: targetId }, (data) => {
              console.log('Presence check:', data);
@@ -559,6 +678,74 @@
          }, 50);
        }
 
+       /**
+        * Open the signaling socket if it is not already connected.
+        *
+        * The client is constructed with `autoConnect: false`, so the socket
+        * stays closed until the user takes an action that needs it (Start, Sign
+        * In, or Check Presence). This keeps the main menu offline until then.
+        */
+       function ensureSocketConnected() {
+         whenSocketReady((socket) => {
+           if (!socket.connected) {
+             console.log('Connecting to signaling service…');
+             socket.connect();
+           }
+         });
+       }
+
+       /**
+        * Show the connecting/negotiating debug view.
+        *
+        * After a peer links, the WebRTC offer/answer + ICE exchange happens
+        * before any data channel opens. Without this the offer view is hidden
+        * and the chat is still hidden, leaving the screen blank. This surfaces
+        * the requestId and a live negotiation log so that gap is debuggable.
+        *
+        * @param keepCallSession - When true (the offer client's link flow) the
+        *   call session is left visible so the QR code is still shown while
+        *   linking. The sign-in flow has no QR, so it hides the call session.
+        */
+       function showConnectingView(keepCallSession = false) {
+         if (!keepCallSession) {
+           document.querySelector('.call-session')?.classList.add('hidden');
+         }
+         document.querySelector('.message-container')?.classList.add('hidden');
+         document.querySelector('.connecting')?.classList.remove('hidden');
+         const info = document.querySelector('#connecting-info');
+         if (info) info.textContent = `requestId: ${requestId}`;
+       }
+
+       /**
+        * Hide the connecting/negotiating debug view and clear its log.
+        */
+       function hideConnectingView() {
+         document.querySelector('.connecting')?.classList.add('hidden');
+         // The offer client keeps its call session (and QR code) visible while
+         // linking; once the transport is live we leave the connecting view, so
+         // hide the call session too (resetConnection re-shows it when returning
+         // to the menu).
+         document.querySelector('.call-session')?.classList.add('hidden');
+         const log = document.querySelector('#connecting-log');
+         if (log) log.innerHTML = '';
+       }
+
+       /**
+        * Append a timestamped line to the connecting debug log.
+        *
+        * @param message - The line to append
+        */
+       function logConnecting(message) {
+         console.log('[connecting]', message);
+         const log = document.querySelector('#connecting-log');
+         if (!log) return;
+         const li = document.createElement('li');
+         const time = new Date().toLocaleTimeString();
+         li.textContent = `${time} — ${message}`;
+         log.appendChild(li);
+         log.scrollTop = log.scrollHeight;
+       }
+
        // Listen for presence broadcasts from the server and keep the UI in sync
        whenSocketReady((socket) => {
          socket.on('presence', (data) => {
@@ -570,6 +757,22 @@
            if (data.requestId === altRequestId) {
              renderPresence(document.querySelector('#answer-presence'), data);
            }
+           // While linking, surface presence in the connecting debug view so the
+           // wait for peer information is visible rather than a blank screen.
+           if (!document.querySelector('.connecting')?.classList.contains('hidden')
+             && (data.requestId === requestId || data.requestId === altRequestId)) {
+             logConnecting(`presence: ${data.deviceCount} device(s), online=${data.online}`);
+           }
+           // If a peer had linked to our offer and presence now shows only us
+           // (deviceCount <= 1), the wallet went offline. Don't sit in the
+           // connecting view or wait out the data-channel/ICE timeout: return to
+           // the QR code and await a fresh link. Skip during a deliberate
+           // disconnect (we're already tearing down).
+           if (peerLinked && !deliberateDisconnect
+             && data.requestId === requestId && data.deviceCount <= 1) {
+             console.log('Peer went offline (presence); returning to QR / awaiting link.');
+             resetConnection('peer offline (presence)');
+           }
          });
        });
 
@@ -578,13 +781,63 @@
        // and the AC2 wallet's `ac2-v1` / `ac2-stream` / `ac2-heartbeat` set.
        client.on('data-channel', routeChannel);
 
+       // Trace the signaling/negotiation exchange into the connecting debug view.
+       // `SignalClient` emits these as it links and exchanges SDP/ICE, so the
+       // otherwise-blank "waiting for peer information" gap now shows progress.
+       client.on('signal', (data) => logConnecting(`signal: ${data?.type ?? ''}`.trim()));
+       client.on('offer-description', () => logConnecting('offer-description'));
+       client.on('answer-description', () => logConnecting('answer-description'));
+       client.on('offer-candidate', () => logConnecting('offer-candidate'));
+       client.on('answer-candidate', () => logConnecting('answer-candidate'));
+
        /**
-        * Reset the connection and UI
+        * Restore the Offer client to its initial, pre-Start state.
+        *
+        * Re-shows the Start/Switch/Forget controls and hides the QR code so the
+        * main menu looks the same as a fresh load, ready for another Start.
+        */
+       function resetOfferView() {
+         const offer = document.querySelector('.offer');
+         offer?.classList.remove('hidden');
+         document.querySelector('.answer')?.classList.add('hidden');
+         document.querySelector('#start')?.classList.remove('hidden');
+         document.querySelector('#toggle')?.classList.remove('hidden');
+         // Hide the awaiting-link Cancel button; we're back to the pre-Start menu.
+         document.querySelector('#offer-cancel')?.classList.add('hidden');
+         // Back on the main menu: reveal Forget again, but only if a connection
+         // has ever been established for the current id.
+         updateForgetButton();
+         document.querySelector('.logo')?.classList.add('hidden');
+       }
+
+       /**
+        * Show the Forget button only on the main menu and only when a connection
+        * has ever been established (`hasConnected`). It is hidden while inviting
+        * (awaiting a link / negotiating) since forgetting mid-invite makes no
+        * sense, and hidden for a never-paired id.
+        */
+       function updateForgetButton() {
+         document.querySelector('#forget')?.classList.toggle('hidden', !hasConnected);
+       }
+
+       /**
+        * Reset the connection and UI.
+        *
+        * A `'manual'` reason (the Disconnect button) returns to the main menu and
+        * does NOT attempt to reconnect: the p2p peer is torn down, the socket is
+        * dropped (matching the "offline until Start" main-menu behavior), and no
+        * new link/offer is initiated. Any other reason (peer close, inactivity,
+        * error) keeps the previous auto-reconnect behavior for the offer client.
+        *
+        * @param reason - Why the connection is being reset
         */
        function resetConnection(reason) {
          if (reason) {
            console.log(`Resetting connection. Reason: ${reason}`);
          }
+         const manual = reason === 'manual';
+         // A new peer must link again before presence can drive another reset.
+         peerLinked = false;
          if (globalThis.dc) {
            globalThis.dc.close();
          }
@@ -597,6 +850,7 @@
          if (heartbeatInterval) clearInterval(heartbeatInterval);
          if (inactivityInterval) clearInterval(inactivityInterval);
 
+         hideConnectingView();
          document.querySelector('.message-container')?.classList.add('hidden');
          document.querySelector('.call-session')?.classList.remove('hidden');
          const msgs = document.querySelector('.messages')
@@ -610,9 +864,46 @@
          heartbeatCount = 0;
          // The messages list was cleared above; drop the stale preview ref too.
          streamPreviewEl = null;
+         // Reset the conversation threads so the next connection reloads its own
+         // store; also clear the thread selector.
+         threads = Object.create(null);
+         activeThid = DEFAULT_THID;
+         threadsReady = false;
+         renderThreadList();
          setConnectionStatus('Connecting…', false);
          updateHeartbeatStatus();
          setAgentStatus(null);
+
+         if (manual) {
+           // User-initiated disconnect: return to the main window and stay there.
+           // Tear down the p2p peer and drop the signaling socket so we are back
+           // to the "offline until Start" main-menu state, then bail before any
+           // reconnect logic runs.
+           //
+           // Mark the teardown as deliberate first: closing the peer below fires
+           // the data channel's `onclose`/`onerror` asynchronously, and this flag
+           // stops those handlers from kicking off a non-manual reset that would
+           // re-show the QR and re-await a link (the "immediately reconnects" bug).
+           deliberateDisconnect = true;
+           //
+           // Stop awaiting a link: detach the outstanding offer `link-message`
+           // listener so a peer that links after we cancelled cannot resurrect
+           // this offer (the whole point of "disconnect stops the link await").
+           if (offerLinkHandler) {
+             client.off?.('link-message', offerLinkHandler);
+             offerLinkHandler = null;
+           }
+           try { client.peerClient?.close(); } catch (e) { /* noop */ }
+           client.peerClient = undefined;
+           client.type = null;
+           delete client.requestId;
+           client.authenticated = false;
+           whenSocketReady((socket) => {
+             if (socket.connected) socket.disconnect();
+           });
+           resetOfferView();
+           return;
+         }
 
          // Show the initial UI again
          const isOffer = !document.querySelector('.offer')?.classList.contains('hidden');
@@ -633,14 +924,17 @@
        }
 
        /**
-        * Clear chat history
+        * Clear the active conversation thread's history (message store + view).
         */
        function clearHistory() {
-         if (connectedAddress) {
-           localStorage.removeItem(`messages_${connectedAddress}`);
-           const messagesDiv = document.querySelector('.messages');
-           messagesDiv.innerHTML = '';
+         const thread = threads[activeThid];
+         if (thread) {
+           thread.messages = [];
+           thread.unread = 0;
+           persistThreads();
          }
+         renderActiveThread();
+         renderThreadList();
        }
 
        /**
@@ -657,48 +951,259 @@
        }
 
        /**
-        * Save a message to local storage
+        * localStorage key for a connected address's thread store.
         */
-       function saveMessage(address, message) {
-         const key = `messages_${address}`;
-         const existing = JSON.parse(localStorage.getItem(key) || '[]');
-         existing.push(message);
-         localStorage.setItem(key, JSON.stringify(existing));
+       function threadsStorageKey(address) {
+         return `threads_${address}`;
        }
 
        /**
-        * Load and display messages from local storage
+        * Persist the in-memory thread store for the connected address.
+        *
+        * No-op when there is no connected address yet (threads still live in
+        * memory and are persisted once the peer address is known).
         */
-       function loadMessages(address) {
-         const key = `messages_${address}`;
-         const messages = JSON.parse(localStorage.getItem(key) || '[]');
-         const messagesDiv = document.querySelector('.messages');
-         messagesDiv.innerHTML = '';
-         messages.forEach((m) => {
-           const className = m.sender === 'me' ? 'local-message' : 'remote-message';
-           messagesDiv.innerHTML += `<div class="message-bubble ${className}">${m.text}</div>`;
+       function persistThreads() {
+         if (!connectedAddress) return;
+         localStorage.setItem(threadsStorageKey(connectedAddress), JSON.stringify(threads));
+       }
+
+       /**
+        * Ensure a thread exists in the in-memory store, creating it if needed.
+        *
+        * @param thid - Thread id (falls back to the default thread)
+        * @param title - Optional human title to attach on first creation
+        * @returns The thread record `{ title, messages, unread }`
+        */
+       function ensureThread(thid, title) {
+         const id = (typeof thid === 'string' && thid) ? thid : DEFAULT_THID;
+         if (!threads[id]) {
+           threads[id] = { title: title || '', messages: [], unread: 0 };
+           renderThreadList();
+         } else if (title && !threads[id].title) {
+           threads[id].title = title;
+         }
+         return threads[id];
+       }
+
+       /**
+        * Load the thread store for a connected address into memory.
+        *
+        * Migrates the legacy flat `messages_<address>` list into the default
+        * thread so history from before threading isn't lost. Always guarantees a
+        * default thread exists.
+        *
+        * @param address - The connected peer address
+        */
+       function loadThreads(address) {
+         threads = Object.create(null);
+         try {
+           const raw = localStorage.getItem(threadsStorageKey(address));
+           if (raw) {
+             const parsed = JSON.parse(raw);
+             if (parsed && typeof parsed === 'object') {
+               Object.keys(parsed).forEach((thid) => {
+                 const t = parsed[thid] || {};
+                 threads[thid] = {
+                   title: t.title || '',
+                   messages: Array.isArray(t.messages) ? t.messages : [],
+                   unread: 0,
+                 };
+               });
+             }
+           }
+         } catch (e) {
+           console.warn('Failed to load threads; starting fresh.', e);
+           threads = Object.create(null);
+         }
+         let migrated = false;
+         if (Object.keys(threads).length === 0) {
+           try {
+             const legacy = JSON.parse(localStorage.getItem(`messages_${address}`) || '[]');
+             if (Array.isArray(legacy) && legacy.length) {
+               threads[DEFAULT_THID] = { title: '', messages: legacy, unread: 0 };
+               migrated = true;
+             }
+           } catch (e) {
+             /* ignore corrupt legacy list */
+           }
+         }
+         ensureThread(DEFAULT_THID);
+         if (migrated) persistThreads();
+       }
+
+       /**
+        * Append a message to a thread's store and persist it.
+        *
+        * @param thid - Thread id
+        * @param message - `{ text, sender }`
+        */
+       function saveThreadMessage(thid, message) {
+         const thread = ensureThread(thid);
+         thread.messages.push(message);
+         persistThreads();
+       }
+
+       /**
+        * Populate the thread selector from the in-memory store, marking the
+        * active thread and showing per-thread unread counts.
+        */
+       function renderThreadList() {
+         const select = document.querySelector('#thread-select');
+         if (!select) return;
+         select.innerHTML = '';
+         Object.keys(threads).forEach((thid) => {
+           const t = threads[thid] || {};
+           const opt = document.createElement('option');
+           opt.value = thid;
+           const base = t.title ? `${t.title} [${thid}]` : thid;
+           const unread = t.unread ? ` (${t.unread})` : '';
+           opt.textContent = `${base}${unread}`;
+           if (thid === activeThid) opt.selected = true;
+           select.appendChild(opt);
          });
-         // Scroll to bottom
+       }
+
+       /**
+        * Render the active thread's stored messages into the chat window.
+        */
+       function renderActiveThread() {
+         const messagesDiv = document.querySelector('.messages');
+         if (!messagesDiv) return;
+         clearStreamPreview();
+         messagesDiv.innerHTML = '';
+         const thread = threads[activeThid];
+         const msgs = (thread && thread.messages) || [];
+         msgs.forEach((m) => {
+           const bubble = document.createElement('div');
+           bubble.className = `message-bubble ${m.sender === 'me' ? 'local-message' : 'remote-message'}`;
+           bubble.textContent = m.text;
+           messagesDiv.appendChild(bubble);
+         });
          messagesDiv.scrollTop = messagesDiv.scrollHeight;
        }
 
        /**
-        * Send a Message to the remote client
+        * Switch the active conversation to the selected thread, re-rendering the
+        * chat window and clearing that thread's unread count.
+        */
+       function switchThread() {
+         const select = document.querySelector('#thread-select');
+         if (!select) return;
+         activeThid = select.value || DEFAULT_THID;
+         const thread = threads[activeThid];
+         if (thread) thread.unread = 0;
+         renderThreadList();
+         renderActiveThread();
+       }
+
+       /**
+        * Create a new conversation thread and switch to it.
+        *
+        * The debug app is the agent side, so it also advertises the updated
+        * thread list to the wallet via a `conversations` control frame.
+        */
+       function newThread() {
+         const suggestion = `t-${Date.now().toString(36)}`;
+         const input = prompt('New thread id:', suggestion);
+         if (input === null) return;
+         const thid = (input || '').trim() || suggestion;
+         ensureThread(thid);
+         activeThid = thid;
+         renderThreadList();
+         renderActiveThread();
+         sendConversations();
+       }
+
+       /**
+        * Advertise the debug app's threads to the wallet as a `conversations`
+        * control frame, mirroring the open-claw plugin's `replayConversationList`
+        * so the wallet's thread list reflects the conversations we hold.
+        *
+        * Best-effort: sent over the stream channel when present, else `ac2-v1`.
+        */
+       function sendConversations() {
+         const list = Object.keys(threads).map((thid) => ({
+           thid,
+           ...(threads[thid] && threads[thid].title ? { title: threads[thid].title } : {}),
+         }));
+         if (list.length === 0) return;
+         const frame = AC2_STREAM_CONTROL_PREFIX + JSON.stringify({ t: 'conversations', threads: list });
+         if (streamChannel && streamChannel.readyState === 'open') {
+           streamChannel.send(frame);
+         } else if (globalThis.dc && globalThis.dc.readyState === 'open') {
+           globalThis.dc.send(frame);
+         }
+       }
+
+       /**
+        * Initialise the thread store for the current connection.
+        *
+        * Called once (guarded by `threadsReady`) from `routeChannel` before any
+        * channel delivers a message, so inbound frames land in threads that are
+        * already loaded from storage rather than being clobbered by a later load.
+        * When the peer address is known its persisted threads are loaded;
+        * otherwise a fresh default thread is used.
+        */
+       function initThreads() {
+         if (threadsReady) return;
+         if (connectedAddress) {
+           loadThreads(connectedAddress);
+         } else {
+           threads = Object.create(null);
+           ensureThread(DEFAULT_THID);
+         }
+         activeThid = DEFAULT_THID;
+         threadsReady = true;
+         renderThreadList();
+         renderActiveThread();
+       }
+
+       /**
+        * Send chat text to the remote client, tagged with the active thread.
+        *
+        * The debug app plays the agent side, so — matching how the wallet
+        * routes/displays agent messages — it sends an STX `finalize` control
+        * frame carrying the active `thid` over the stream channel when present.
+        * Falls back to a `{thid,text}` envelope on `ac2-v1`, then to plain text
+        * for a legacy `liquid` peer.
+        *
+        * @param text - The message text to send
+        */
+       function sendChatText(text) {
+         if (isAc2 && streamChannel && streamChannel.readyState === 'open') {
+           streamChannel.send(
+             AC2_STREAM_CONTROL_PREFIX + JSON.stringify({ t: 'finalize', thid: activeThid, text })
+           );
+           return;
+         }
+         if (isAc2 && globalThis.dc && globalThis.dc.readyState === 'open') {
+           globalThis.dc.send(JSON.stringify({ thid: activeThid, text }));
+           return;
+         }
+         if (globalThis.dc && globalThis.dc.readyState === 'open') {
+           globalThis.dc.send(text);
+         }
+       }
+
+       /**
+        * Send a Message to the remote client in the active conversation thread.
         */
        function sendMessage() {
          const messages = document.querySelector('.messages')
          const message = document.querySelector('#message')
          if (message.value.trim() && globalThis.dc && globalThis.dc.readyState === 'open') {
            const text = message.value.trim();
-           globalThis.dc.send(text)
-           messages.innerHTML += `<div class="message-bubble local-message">${text}</div>`
+           sendChatText(text);
+           const bubble = document.createElement('div');
+           bubble.className = 'message-bubble local-message';
+           bubble.textContent = text;
+           messages.appendChild(bubble);
            message.value = ''
            lastUserActivity = Date.now();
            messages.scrollTop = messages.scrollHeight;
            pulseIndicator();
-           if (connectedAddress) {
-             saveMessage(connectedAddress, { text, sender: 'me' });
-           }
+           saveThreadMessage(activeThid, { text, sender: 'me' });
          }
        }
        /**
@@ -778,26 +1283,37 @@
        }
 
        /**
-        * Append a remote (peer/agent) chat bubble and persist it.
+        * Append a remote (peer/agent) chat bubble to its thread and persist it.
         *
-        * Uses textContent so remote content can never inject markup.
+        * The message is stored in the thread named by `thid` (defaulting to the
+        * active thread). It is only rendered into the chat window when it belongs
+        * to the active conversation; otherwise its thread's unread count is bumped
+        * so the thread selector shows there's something new. Uses textContent so
+        * remote content can never inject markup.
         *
         * @param text - The message text to render
+        * @param thid - The thread the message belongs to (defaults to active)
         */
-       function renderRemoteMessage(text) {
+       function renderRemoteMessage(text, thid) {
          if (!text) return;
-         ensureMessagesVisible();
-         const messages = document.querySelector('.messages');
-         if (!messages) return;
-         pulseIndicator();
-         const bubble = document.createElement('div');
-         bubble.className = 'message-bubble remote-message';
-         bubble.textContent = text;
-         messages.appendChild(bubble);
-         messages.scrollTop = messages.scrollHeight;
+         const targetThid = (typeof thid === 'string' && thid) ? thid : activeThid;
+         ensureThread(targetThid);
+         saveThreadMessage(targetThid, { text, sender: 'peer' });
          lastUserActivity = Date.now();
-         if (connectedAddress) {
-           saveMessage(connectedAddress, { text, sender: 'peer' });
+         if (targetThid === activeThid) {
+           ensureMessagesVisible();
+           const messages = document.querySelector('.messages');
+           if (!messages) return;
+           pulseIndicator();
+           const bubble = document.createElement('div');
+           bubble.className = 'message-bubble remote-message';
+           bubble.textContent = text;
+           messages.appendChild(bubble);
+           messages.scrollTop = messages.scrollHeight;
+         } else {
+           const thread = threads[targetThid];
+           if (thread) thread.unread = (thread.unread || 0) + 1;
+           renderThreadList();
          }
        }
 
@@ -805,9 +1321,15 @@
         * Update the live streaming-preview bubble with the agent's cumulative
         * `preview` text (from the `ac2-stream` channel). Created on first use.
         *
+        * Live previews are only shown for the active thread; a preview for a
+        * background thread is ignored (its `finalize` will still be stored).
+        *
         * @param text - Cumulative preview text
+        * @param thid - The thread the preview belongs to (defaults to active)
         */
-       function updateStreamPreview(text) {
+       function updateStreamPreview(text, thid) {
+         const targetThid = (typeof thid === 'string' && thid) ? thid : activeThid;
+         if (targetThid !== activeThid) return;
          ensureMessagesVisible();
          const messages = document.querySelector('.messages');
          if (!messages) return;
@@ -835,15 +1357,17 @@
         * `finalize`). Falls back to whatever the preview already showed.
         *
         * @param text - Final message text
+        * @param thid - The thread the message belongs to (defaults to active)
         */
-       function commitStreamPreview(text) {
+       function commitStreamPreview(text, thid) {
+         const targetThid = (typeof thid === 'string' && thid) ? thid : activeThid;
          const finalText = (
            (typeof text === 'string' && text) ||
-           (streamPreviewEl ? streamPreviewEl.textContent : '') ||
+           (targetThid === activeThid && streamPreviewEl ? streamPreviewEl.textContent : '') ||
            ''
          ).trim();
-         clearStreamPreview();
-         if (finalText) renderRemoteMessage(finalText);
+         if (targetThid === activeThid) clearStreamPreview();
+         if (finalText) renderRemoteMessage(finalText, targetThid);
        }
 
        /**
@@ -872,14 +1396,34 @@
              return true; // malformed control frame, swallow
            }
            console.log('Stream control frame:', frame);
-           if (frame && typeof frame.thid === 'string') currentThid = frame.thid;
-           setAgentStatus(frame);
+           // Route by the frame's thread; unknown threads are created so a new
+           // conversation started by the peer shows up in the selector.
+           const fthid = (frame && typeof frame.thid === 'string' && frame.thid) ? frame.thid : activeThid;
+           if (frame && frame.t === 'conversations') {
+             // The peer advertised the conversations it holds; merge them into
+             // our thread list so they can be selected.
+             if (Array.isArray(frame.threads)) {
+               frame.threads
+                 .filter((t) => t && typeof t.thid === 'string' && t.thid)
+                 .forEach((t) => ensureThread(t.thid, typeof t.title === 'string' ? t.title : ''));
+               renderThreadList();
+             }
+             return true;
+           }
+           ensureThread(fthid);
+           if (frame && frame.t === 'history') {
+             // The peer replayed a thread's history; restore it into that thread.
+             mergeThreadHistory(fthid, Array.isArray(frame.messages) ? frame.messages : []);
+             return true;
+           }
+           // Only reflect agent status for the active conversation.
+           if (fthid === activeThid) setAgentStatus(frame);
            if (frame && frame.t === 'preview') {
-             if (typeof frame.text === 'string') updateStreamPreview(frame.text);
+             if (typeof frame.text === 'string') updateStreamPreview(frame.text, fthid);
            } else if (frame && frame.t === 'finalize') {
-             commitStreamPreview(typeof frame.text === 'string' ? frame.text : '');
+             commitStreamPreview(typeof frame.text === 'string' ? frame.text : '', fthid);
            } else if (frame && frame.t === 'discard') {
-             clearStreamPreview();
+             if (fthid === activeThid) clearStreamPreview();
            }
            return true;
          }
@@ -896,9 +1440,10 @@
              obj = null;
            }
            if (obj && typeof obj === 'object') {
-             if (typeof obj.thid === 'string') currentThid = obj.thid;
+             const othid = (typeof obj.thid === 'string' && obj.thid) ? obj.thid : activeThid;
+             ensureThread(othid);
              if (typeof obj.text === 'string' && obj.text.trim()) {
-               renderRemoteMessage(obj.text.trim());
+               renderRemoteMessage(obj.text.trim(), othid);
              } else {
                console.log('AC2 envelope received (not chat):', obj);
              }
@@ -906,8 +1451,31 @@
            }
          }
          // Bare-string chat (legacy `liquid` peer or plain-text AC2 message).
-         renderRemoteMessage(trimmed);
+         renderRemoteMessage(trimmed, activeThid);
          return true;
+       }
+
+       /**
+        * Merge a replayed `history` frame's messages into a thread's store,
+        * replacing our copy of that thread so it is idempotent. Re-renders the
+        * chat window when the restored thread is the active one.
+        *
+        * @param thid - The thread to restore
+        * @param messages - The replayed `[{ role, text }]` list
+        */
+       function mergeThreadHistory(thid, messages) {
+         const thread = ensureThread(thid);
+         // The peer is the agent from our POV, so `role: 'assistant'` is the peer
+         // and `role: 'user'` is us (mirrors how we send history).
+         thread.messages = messages
+           .filter((m) => m && typeof m.text === 'string' && m.text.trim())
+           .map((m) => ({ text: m.text, sender: m.role === 'user' ? 'me' : 'peer' }));
+         persistThreads();
+         if (thid === activeThid) {
+           renderActiveThread();
+         } else {
+           renderThreadList();
+         }
        }
 
        /**
@@ -922,6 +1490,16 @@
         */
        function routeChannel(channel) {
          console.log('Data channel negotiated:', channel.label);
+         // The p2p transport is live: leave the connecting/negotiating debug
+         // view and show the chat.
+         hideConnectingView();
+         // Load this connection's conversation threads once, before any channel
+         // delivers a message, so inbound frames route into loaded threads.
+         initThreads();
+         // A negotiated data channel means the pairing reached a live p2p
+         // connection, so implicitly remember this requestId for reuse across
+         // reloads (and enable Forget).
+         saveConnectedRequestId();
          switch (channel.label) {
            case 'ac2-heartbeat':
              isAc2 = true;
@@ -1019,9 +1597,8 @@
          }
          updateHeartbeatStatus();
 
-         if (connectedAddress) {
-           loadMessages(connectedAddress);
-         }
+         // Conversation threads are loaded once in `routeChannel` (before any
+         // message arrives), so nothing to load here.
 
          lastUserActivity = Date.now();
 
@@ -1064,10 +1641,14 @@
          }
 
          dataChannel.onclose = () => {
+           // A deliberate (manual) disconnect closes the peer itself; ignore the
+           // resulting close so we don't bounce back into a reconnect.
+           if (deliberateDisconnect) return;
            resetConnection('data channel closed by peer');
          };
 
          dataChannel.onerror = (error) => {
+           if (deliberateDisconnect) return;
            console.error("Data channel error:", error);
            resetConnection('data channel error');
          };
@@ -1076,6 +1657,12 @@
         * Create a peer connection, wait for an offer and send an answer to the remote client
         */
        async function handleOfferClient() {
+         // Starting a fresh connection clears any prior deliberate-disconnect
+         // state so later genuine drops still reset the UI.
+         deliberateDisconnect = false;
+         // Opening the app leaves the socket closed; connect it now that the user
+         // has started the offer flow.
+         ensureSocketConnected();
          // Peer to the remote client and await their offer. Negotiated channels
          // are dispatched by the `data-channel` listener (`routeChannel`), so we
          // only need to surface errors here.
@@ -1084,10 +1671,26 @@
            console.error('Peer connection error:', err);
          })
 
-         // Once the link message is received by the remote wallet, hide the offer
-         client.once('link-message', (data) => {
+         // Once the link message is received by the remote wallet, the WebRTC
+         // offer/answer + ICE exchange runs before any data channel opens. Show
+         // the connecting/negotiating debug view for that window instead of
+         // leaving the screen blank while we wait for peer information.
+         //
+         // Track the handler in `offerLinkHandler` (and clear any stale one from a
+         // previous Start) so a manual Disconnect can detach it and stop the link
+         // await. The handler nulls the ref on fire since `once` self-removes.
+         if (offerLinkHandler) client.off?.('link-message', offerLinkHandler);
+         offerLinkHandler = (data) => {
+           offerLinkHandler = null;
+           // A peer has linked: arm presence-driven teardown so that if the wallet
+           // later goes offline we return to the QR / awaiting-link state.
+           peerLinked = true;
            console.log('Link message received:', data);
-           document.querySelector('.offer')?.classList.add('hidden')
+           // Keep the offer view (and its QR code) visible while linking so the
+           // QR is still shown during the WebRTC offer/answer + ICE exchange;
+           // surface the negotiation log alongside it.
+           showConnectingView(true);
+           logConnecting(`linked${data && data.wallet ? ` with ${data.wallet}` : ''}; negotiating peer connection…`);
            // The address should be available here if the wallet provides it in the link message
            // But the type LinkMessage in signal.ts only has { credId, requestId, wallet }
            // Looking at handleSignChallenge, it sends { requestId, origin, type, address, signature, device }
@@ -1095,7 +1698,8 @@
            if (data.wallet) {
              connectedAddress = data.wallet;
            }
-         })
+         };
+         client.once('link-message', offerLinkHandler)
 
          // Update the render
          const image = document.querySelector('.logo')
@@ -1109,6 +1713,10 @@
 
          document.querySelector('#start')?.classList.add('hidden')
          document.querySelector('#toggle')?.classList.add('hidden')
+         // Inviting/awaiting a link: hide Forget (it only belongs on the menu).
+         document.querySelector('#forget')?.classList.add('hidden')
+         // Now awaiting a peer link: offer a Cancel that stops the link await.
+         document.querySelector('#offer-cancel')?.classList.remove('hidden')
        }
 
        /**
@@ -1118,6 +1726,12 @@
         * before they can peer with the remote client.
         */
        async function handleSignChallenge() {
+         // Starting a fresh connection clears any prior deliberate-disconnect
+         // state so later genuine drops still reset the UI.
+         deliberateDisconnect = false;
+         // Opening the app leaves the socket closed; connect it now that the user
+         // has started the answer flow.
+         ensureSocketConnected();
          connectedAddress = testAccount.addr;
          // Sign in to the service with a new credential
          await client.attestation(async (challenge) => ({
@@ -1132,6 +1746,12 @@
          //await client.assertion()
 
          document.querySelector('.answer')?.classList.add('hidden')
+
+         // Signed in; the offer/answer + ICE exchange runs before any data
+         // channel opens. Show the connecting/negotiating debug view for that
+         // window instead of leaving the screen blank.
+         showConnectingView();
+         logConnecting('signed in; negotiating peer connection…');
 
          // Create the Peer Connection and await the remote client's answer.
          // Negotiated channels are dispatched by `routeChannel`.
@@ -1150,9 +1770,13 @@
        }
 
        /**
-        * Update the local (offer) requestId from its input, persist it, and keep
-        * the remote (alt) id in sync when it still mirrors the local id. Lets us
-        * reuse a known requestId across reloads to test reconnect/reuse.
+        * Update the local (offer) requestId from its input and keep the remote
+        * (alt) id in sync when it still mirrors the local id. Lets us reuse a
+        * known requestId across reloads to test reconnect/reuse.
+        *
+        * Editing an id resets `hasConnected` and does NOT persist: an id is only
+        * remembered once it actually connects (see `saveConnectedRequestId`), so
+        * typing a new id to try never leaves a stale, never-paired id behind.
         */
        function handleLocalRequestId() {
          const input = document.querySelector('#local-request');
@@ -1160,7 +1784,7 @@
          if (!value) return;
          const mirrored = altRequestId === requestId;
          requestId = value;
-         localStorage.setItem(REQUEST_ID_STORAGE_KEY, requestId);
+         hasConnected = false;
          if (mirrored) {
            altRequestId = requestId;
            const alt = document.querySelector('#alt-request');
@@ -1169,14 +1793,35 @@
        }
 
        /**
+        * Persist the current requestId once it has connected.
+        *
+        * Called from `routeChannel` when a data channel is negotiated (i.e. the
+        * pairing reached a live p2p connection). This is the implicit
+        * save-on-connect: only a requestId that actually paired is remembered
+        * across reloads, and only a remembered id can be forgotten.
+        */
+       function saveConnectedRequestId() {
+         hasConnected = true;
+         localStorage.setItem(REQUEST_ID_STORAGE_KEY, requestId);
+       }
+
+       /**
         * Forget the current requestId, mirroring the open-claw plugin's `ac2
         * forget`: drop the persisted pairing id and mint a fresh UUID so the next
         * pairing starts clean. Resets the visible ids and clears presence.
+        *
+        * We only forget an id that has actually connected (either this run or a
+        * remembered one from storage). Forgetting a never-paired id would be a
+        * no-op that just churns the visible id, so we warn and bail instead.
         */
        function forgetRequestId() {
+         if (!hasConnected && !localStorage.getItem(REQUEST_ID_STORAGE_KEY)) {
+           console.warn('Nothing to forget: requestId has not connected yet.');
+           return;
+         }
          localStorage.removeItem(REQUEST_ID_STORAGE_KEY);
+         hasConnected = false;
          requestId = SignalClient.generateRequestId();
-         localStorage.setItem(REQUEST_ID_STORAGE_KEY, requestId);
          altRequestId = requestId;
          const local = document.querySelector('#local-request');
          if (local) local.value = requestId;
@@ -1184,45 +1829,78 @@
          if (alt) alt.value = altRequestId;
          renderPresence(document.querySelector('#offer-presence'), null);
          renderPresence(document.querySelector('#answer-presence'), null);
+         // Nothing left to forget for the fresh id, so hide the button.
+         updateForgetButton();
          console.log('Forgot requestId; new local id:', requestId);
        }
 
        /**
-        * Send the stored conversation history to the wallet as an `ac2-stream`
-        * `history` control frame, aligning with the open-claw reference plugin's
-        * `replayConversationHistory`. Local messages map to `user`, remote to
-        * `assistant`; sent over the stream channel when present, else `ac2-v1`.
+        * Send every conversation thread's stored history to the wallet, one
+        * `ac2-stream` `history` control frame per thread (each tagged with its own
+        * `thid`), aligning with the open-claw reference plugin's
+        * `replayConversationHistory`. The wallet restores each frame independently
+        * via `setThreadHistory`, so all conversations are replayed at once.
+        *
+        * The debug app plays the agent/plugin side of the conversation, so from
+        * the wallet's point of view its own outbound messages (`sender: 'me'`)
+        * are the `assistant` and the wallet's messages we received
+        * (`sender: 'peer'`) are the `user`. This mirrors how the wallet restores
+        * a `history` frame (`role: 'user'` → its own `sender: 'me'`,
+        * `role: 'assistant'` → the peer's `sender: 'peer'`); mapping them the
+        * other way round is what made the replayed conversation appear reversed.
+        *
+        * We also advertise the full thread list first (`conversations` frame) so
+        * the wallet's selector reflects every conversation we're about to replay.
+        * Sent over the stream channel when present, else `ac2-v1`.
         */
        function sendHistory() {
-         if (!connectedAddress) {
-           console.warn('No connected peer; cannot send history.');
-           return;
-         }
-         const stored = JSON.parse(localStorage.getItem(`messages_${connectedAddress}`) || '[]');
-         const messages = stored
-           .filter((m) => m && typeof m.text === 'string' && m.text.trim())
-           .map((m) => ({
-             role: m.sender === 'me' ? 'user' : 'assistant',
-             text: m.text,
-           }));
-         if (messages.length === 0) {
-           console.warn('No stored history to send.');
-           return;
-         }
-         const frame = AC2_STREAM_CONTROL_PREFIX + JSON.stringify({
-           t: 'history',
-           thid: currentThid,
-           messages,
+         const send = (frame) => {
+           if (streamChannel && streamChannel.readyState === 'open') {
+             streamChannel.send(frame);
+             return true;
+           }
+           if (globalThis.dc && globalThis.dc.readyState === 'open') {
+             globalThis.dc.send(frame);
+             return true;
+           }
+           return false;
+         };
+         // Make sure the wallet knows about every thread before we replay them.
+         sendConversations();
+         let sentThreads = 0;
+         let sentMessages = 0;
+         let channelMissing = false;
+         Object.keys(threads).forEach((thid) => {
+           const thread = threads[thid];
+           const stored = (thread && thread.messages) || [];
+           const messages = stored
+             .filter((m) => m && typeof m.text === 'string' && m.text.trim())
+             .map((m) => ({
+               role: m.sender === 'me' ? 'assistant' : 'user',
+               text: m.text,
+             }));
+           if (messages.length === 0) return;
+           const frame = AC2_STREAM_CONTROL_PREFIX + JSON.stringify({
+             t: 'history',
+             thid,
+             messages,
+           });
+           if (send(frame)) {
+             sentThreads += 1;
+             sentMessages += messages.length;
+           } else {
+             channelMissing = true;
+           }
          });
-         if (streamChannel && streamChannel.readyState === 'open') {
-           streamChannel.send(frame);
-         } else if (globalThis.dc && globalThis.dc.readyState === 'open') {
-           globalThis.dc.send(frame);
-         } else {
+         if (channelMissing) {
            console.warn('No open channel to send history over.');
            return;
          }
-         console.log(`Sent history (${messages.length} message(s)) on thid ${currentThid}`);
+         if (sentThreads === 0) {
+           console.warn('No stored history to send.');
+           return;
+         }
+         console.log(`Sent history for ${sentThreads} thread(s) (${sentMessages} message(s) total)`);
        }
 
 
@@ -1237,7 +1915,9 @@
        globalThis.sendHistory = sendHistory
        globalThis.resetConnection = resetConnection
        globalThis.checkPresence = checkPresence
- })
+       globalThis.switchThread = switchThread
+       globalThis.newThread = newThread
+})
      </script>
 </body>
 </html>

--- a/src/views/index.hbs
+++ b/src/views/index.hbs
@@ -142,6 +142,12 @@
           border-bottom-left-radius: 4px;
       }
 
+      /* Live, still-streaming agent preview (committed on `finalize`). */
+      .message-bubble.stream-preview {
+          opacity: 0.7;
+          font-style: italic;
+      }
+
       .chat-input-area {
           display: flex;
           gap: 10px;
@@ -231,6 +237,42 @@
       label {
           font-size: 1.2em;
           font-weight: bold;
+      }
+      .presence {
+          font-size: 0.9em;
+          margin: 8px 0;
+          color: #aaa;
+      }
+      .presence.online {
+          color: #4CAF50;
+      }
+      .presence.offline {
+          color: #ff4444;
+      }
+      .status-bar {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 12px;
+          align-items: center;
+          font-size: 0.8em;
+          color: #aaa;
+          padding: 4px 10px 10px;
+          border-bottom: 1px solid #333;
+          margin-bottom: 10px;
+      }
+      .status-bar .status-pill {
+          padding: 2px 8px;
+          border-radius: 10px;
+          background: #242424;
+          border: 1px solid #333;
+      }
+      .status-bar .status-pill.ac2 {
+          border-color: #646cff;
+          color: #646cff;
+      }
+      .status-bar .status-pill.agent-active {
+          border-color: #4CAF50;
+          color: #4CAF50;
       }
       @media (prefers-color-scheme: light) {
           :root {
@@ -367,8 +409,14 @@
          ],
          iceCandidatePoolSize: 10,
        }
-       // RequestId for this client
-       const requestId = SignalClient.generateRequestId()
+       // RequestId for this client. Use a generated UUID as the basis, but
+       // persist it and allow editing so the same id can be reused across
+       // reloads to exercise reconnect/reuse against a wallet that remembers it.
+       // `forgetRequestId()` clears the saved id and mints a fresh one, mirroring
+       // the open-claw reference plugin's `ac2 forget`.
+       const REQUEST_ID_STORAGE_KEY = 'liquid_request_id'
+       let requestId = localStorage.getItem(REQUEST_ID_STORAGE_KEY) || SignalClient.generateRequestId()
+       localStorage.setItem(REQUEST_ID_STORAGE_KEY, requestId)
        // RequestId for a remote client
        let altRequestId = requestId
        // Globals for connection management
@@ -376,6 +424,22 @@
        let heartbeatInterval = null;
        let inactivityInterval = null;
        let connectedAddress = null;
+       // AC2 data-channel state. An AC2 wallet negotiates dedicated channels
+       // (`ac2-v1`, `ac2-stream`, `ac2-heartbeat`) instead of the single legacy
+       // `liquid` channel, so we route by label and track them here.
+       let isAc2 = false;
+       let heartbeatChannel = null;
+       let streamChannel = null;
+       let heartbeatCount = 0;
+       // STX (0x02) prefix for `ac2-stream` control frames (matches the wallet
+       // and the open-claw reference plugin's stream protocol).
+       const AC2_STREAM_CONTROL_PREFIX = '\u0002';
+       // Thread id last seen from the wallet/agent; used when replaying history
+       // back to the wallet. Defaults to the plugin's default thread.
+       let currentThid = 'default';
+       // Live "still streaming" preview bubble for the agent's `ac2-stream`
+       // preview frames; committed as a normal message on `finalize`.
+       let streamPreviewEl = null;
 
        // Render the UI
        const app = document.querySelector('#app');
@@ -388,16 +452,21 @@
                </a>
                <hgroup>
                <h1>Offer Client</h1>
-               <h2>Local ID: ${requestId}</h2>
                </hgroup>
+               <label for="local-request">Local ID:</label>
+               <input id="local-request" value="${requestId}" onchange="handleLocalRequestId()"/>
+               <p id="offer-presence" class="presence"></p>
                <button id="start" onclick="handleOfferClient()">Start</button>
                <button id="toggle" onclick="toggle()">Switch</button>
+               <button class="danger" onclick="forgetRequestId()">Forget</button>
            </div>
            <div class="answer hidden">
                <h1>Answer Client</h1>
                <label for="alt-request">Remote ID:</label>
                <input id="alt-request" value="${altRequestId}" onchange="handleAlternativeRequestId()"/>
+               <button id="check-presence" onclick="checkPresence()">Check Presence</button>
                <button id="attestation" onclick="handleSignChallenge()">Sign In</button>
+               <p id="answer-presence" class="presence"></p>
            </div>
        </div>
        <div class="message-container hidden">
@@ -407,9 +476,15 @@
                    <h1>Messages</h1>
                </div>
                <div class="chat-header-actions">
+                   <button onclick="sendHistory()">Send History</button>
                    <button class="danger" onclick="clearHistory()">Clear History</button>
                    <button class="danger" onclick="resetConnection('manual')">Disconnect</button>
                </div>
+           </div>
+           <div class="status-bar">
+               <span class="status-pill" id="connection-status">Connecting…</span>
+               <span class="status-pill" id="heartbeat-status">Heartbeats: 0</span>
+               <span class="status-pill hidden" id="agent-status">Agent: idle</span>
            </div>
            <div class="messages"></div>
            <div class="chat-input-area">
@@ -421,6 +496,89 @@
    `
 
        /**
+        * Render presence information into the given element
+        *
+        * @param el - The element to render into
+        * @param data - Presence payload { requestId, deviceCount, online }
+        */
+       function renderPresence(el, data) {
+         if (!el) return;
+         if (!data) {
+           el.textContent = '';
+           el.classList.remove('online', 'offline');
+           return;
+         }
+         const status = data.online ? 'online' : 'offline';
+         el.textContent = `Presence: ${status} — ${data.deviceCount} device(s) connected for ${data.requestId}`;
+         el.classList.toggle('online', !!data.online);
+         el.classList.toggle('offline', !data.online);
+       }
+
+       /**
+        * Query the presence for a requestId on demand
+        *
+        * Used to detect whether there is anyone available to connect to before
+        * attempting to (re)connect. Emits the `presence` event and renders the ack.
+        *
+        * @param id - Optional requestId to query, defaults to the remote (alt) ID
+        */
+       function checkPresence(id) {
+         const targetId = typeof id === 'string' ? id : altRequestId;
+         whenSocketReady((socket) => {
+           socket.emit('presence', { requestId: targetId }, (data) => {
+             console.log('Presence check:', data);
+             renderPresence(document.querySelector('#answer-presence'), data);
+             if (data && !data.online) {
+               console.warn(`No devices online for ${targetId}; reconnect may not succeed.`);
+             }
+           });
+         });
+       }
+
+       /**
+        * Run a callback once the signaling socket is available.
+        *
+        * `SignalClient` initializes its socket asynchronously (it dynamically
+        * imports socket.io-client), so `client.socket` can be undefined right
+        * after construction. This guard avoids the "cannot read 'on' of
+        * undefined" crash that previously prevented presence updates (and every
+        * handler wired after it) from ever registering.
+        *
+        * @param cb - Invoked with the ready socket
+        */
+       function whenSocketReady(cb) {
+         if (client.socket) {
+           cb(client.socket);
+           return;
+         }
+         const timer = setInterval(() => {
+           if (client.socket) {
+             clearInterval(timer);
+             cb(client.socket);
+           }
+         }, 50);
+       }
+
+       // Listen for presence broadcasts from the server and keep the UI in sync
+       whenSocketReady((socket) => {
+         socket.on('presence', (data) => {
+           console.log('Presence update:', data);
+           if (!data) return;
+           if (data.requestId === requestId) {
+             renderPresence(document.querySelector('#offer-presence'), data);
+           }
+           if (data.requestId === altRequestId) {
+             renderPresence(document.querySelector('#answer-presence'), data);
+           }
+         });
+       });
+
+       // Route every negotiated data channel by label. Registered once so it
+       // survives reconnects; it handles both the legacy single `liquid` channel
+       // and the AC2 wallet's `ac2-v1` / `ac2-stream` / `ac2-heartbeat` set.
+       client.on('data-channel', routeChannel);
+
+       /**
         * Reset the connection and UI
         */
        function resetConnection(reason) {
@@ -429,6 +587,12 @@
          }
          if (globalThis.dc) {
            globalThis.dc.close();
+         }
+         if (heartbeatChannel) {
+           try { heartbeatChannel.close(); } catch (e) { /* noop */ }
+         }
+         if (streamChannel) {
+           try { streamChannel.close(); } catch (e) { /* noop */ }
          }
          if (heartbeatInterval) clearInterval(heartbeatInterval);
          if (inactivityInterval) clearInterval(inactivityInterval);
@@ -439,6 +603,16 @@
          msgs.innerHTML = '';
 
          connectedAddress = null;
+         // Reset AC2 channel + status state for the next connection
+         isAc2 = false;
+         heartbeatChannel = null;
+         streamChannel = null;
+         heartbeatCount = 0;
+         // The messages list was cleared above; drop the stale preview ref too.
+         streamPreviewEl = null;
+         setConnectionStatus('Connecting…', false);
+         updateHeartbeatStatus();
+         setAgentStatus(null);
 
          // Show the initial UI again
          const isOffer = !document.querySelector('.offer')?.classList.contains('hidden');
@@ -528,7 +702,308 @@
          }
        }
        /**
-        * Handle the data channel
+        * Update the connection status pill
+        *
+        * @param text - Status text to show
+        * @param ac2 - Whether the peer is an AC2 wallet (highlights the pill)
+        */
+       function setConnectionStatus(text, ac2) {
+         const el = document.getElementById('connection-status');
+         if (!el) return;
+         el.textContent = text;
+         el.classList.toggle('ac2', !!ac2);
+       }
+
+       /**
+        * Refresh the heartbeat counter pill
+        */
+       function updateHeartbeatStatus() {
+         const el = document.getElementById('heartbeat-status');
+         if (el) el.textContent = `Heartbeats: ${heartbeatCount}`;
+       }
+
+       /**
+        * Count a heartbeat and pulse the indicator
+        *
+        * Any inbound liveness frame (legacy empty message, or an `ac2-heartbeat`
+        * ping/pong) counts. Keeps the status bar and indicator in sync so the
+        * debug app reflects liveness even against an AC2 wallet.
+        */
+       function noteHeartbeat() {
+         heartbeatCount += 1;
+         lastUserActivity = Date.now();
+         pulseIndicator();
+         updateHeartbeatStatus();
+       }
+
+       /**
+        * Render the agent presence reported over the `ac2-stream` channel
+        *
+        * @param frame - Parsed stream control frame, or null to reset to idle
+        */
+       function setAgentStatus(frame) {
+         const el = document.getElementById('agent-status');
+         if (!el) return;
+         if (!frame) {
+           el.textContent = 'Agent: idle';
+           el.classList.remove('agent-active');
+           el.classList.add('hidden');
+           return;
+         }
+         let label = 'idle';
+         if (frame.t === 'preview') {
+           label = frame.phase || 'thinking';
+           if (frame.detail) label += ` (${frame.detail})`;
+         } else if (frame.t === 'tool') {
+           label = `tool${frame.name ? ` (${frame.name})` : ''}`;
+         } else if (frame.t === 'finalize' || frame.t === 'discard') {
+           label = 'idle';
+         } else {
+           label = frame.t;
+         }
+         el.textContent = `Agent: ${label}`;
+         el.classList.toggle('agent-active', label !== 'idle');
+         el.classList.remove('hidden');
+       }
+
+       /**
+        * Ensure the message view is visible.
+        *
+        * Inbound chat can arrive on `ac2-stream` before (or without) the
+        * `ac2-v1` handler has revealed the chat UI, so surface it on demand.
+        */
+       function ensureMessagesVisible() {
+         document.querySelector('.message-container')?.classList.remove('hidden');
+         document.querySelector('.call-session')?.classList.add('hidden');
+       }
+
+       /**
+        * Append a remote (peer/agent) chat bubble and persist it.
+        *
+        * Uses textContent so remote content can never inject markup.
+        *
+        * @param text - The message text to render
+        */
+       function renderRemoteMessage(text) {
+         if (!text) return;
+         ensureMessagesVisible();
+         const messages = document.querySelector('.messages');
+         if (!messages) return;
+         pulseIndicator();
+         const bubble = document.createElement('div');
+         bubble.className = 'message-bubble remote-message';
+         bubble.textContent = text;
+         messages.appendChild(bubble);
+         messages.scrollTop = messages.scrollHeight;
+         lastUserActivity = Date.now();
+         if (connectedAddress) {
+           saveMessage(connectedAddress, { text, sender: 'peer' });
+         }
+       }
+
+       /**
+        * Update the live streaming-preview bubble with the agent's cumulative
+        * `preview` text (from the `ac2-stream` channel). Created on first use.
+        *
+        * @param text - Cumulative preview text
+        */
+       function updateStreamPreview(text) {
+         ensureMessagesVisible();
+         const messages = document.querySelector('.messages');
+         if (!messages) return;
+         if (!streamPreviewEl) {
+           streamPreviewEl = document.createElement('div');
+           streamPreviewEl.className = 'message-bubble remote-message stream-preview';
+           messages.appendChild(streamPreviewEl);
+         }
+         streamPreviewEl.textContent = text;
+         messages.scrollTop = messages.scrollHeight;
+       }
+
+       /**
+        * Remove the live streaming-preview bubble (on `discard`/reset).
+        */
+       function clearStreamPreview() {
+         if (streamPreviewEl) {
+           streamPreviewEl.remove();
+           streamPreviewEl = null;
+         }
+       }
+
+       /**
+        * Commit the streaming preview as the agent's final message (on
+        * `finalize`). Falls back to whatever the preview already showed.
+        *
+        * @param text - Final message text
+        */
+       function commitStreamPreview(text) {
+         const finalText = (
+           (typeof text === 'string' && text) ||
+           (streamPreviewEl ? streamPreviewEl.textContent : '') ||
+           ''
+         ).trim();
+         clearStreamPreview();
+         if (finalText) renderRemoteMessage(finalText);
+       }
+
+       /**
+        * Handle an inbound AC2 frame from either `ac2-stream` or `ac2-v1`.
+        *
+        * AC2 peers (a wallet + its agent) don't exchange plain frames the way a
+        * legacy `liquid` peer does: the agent emits STX(0x02)-prefixed control
+        * frames (`preview`/`finalize`/`tool`/…) carrying its reply text over
+        * `ac2-stream`, while the wallet sends chat as a plain `{ thid, text }`
+        * JSON envelope. Decode both so the debug app actually displays what the
+        * wallet/agent sends instead of only reflecting its status.
+        *
+        * @param raw - The raw string frame
+        * @returns true if the frame was consumed (control frame or chat)
+        */
+       function handleAc2Frame(raw) {
+         if (typeof raw !== 'string' || raw.length === 0) return false;
+         lastUserActivity = Date.now();
+         // STX-prefixed control frame: drives the agent status pill plus the
+         // streamed live preview / finalized reply.
+         if (raw.charCodeAt(0) === 0x02) {
+           let frame;
+           try {
+             frame = JSON.parse(raw.slice(1));
+           } catch (err) {
+             return true; // malformed control frame, swallow
+           }
+           console.log('Stream control frame:', frame);
+           if (frame && typeof frame.thid === 'string') currentThid = frame.thid;
+           setAgentStatus(frame);
+           if (frame && frame.t === 'preview') {
+             if (typeof frame.text === 'string') updateStreamPreview(frame.text);
+           } else if (frame && frame.t === 'finalize') {
+             commitStreamPreview(typeof frame.text === 'string' ? frame.text : '');
+           } else if (frame && frame.t === 'discard') {
+             clearStreamPreview();
+           }
+           return true;
+         }
+         const trimmed = raw.trim();
+         if (!trimmed) return false;
+         // The wallet sends chat as `{ thid, text }` JSON; other AC2 envelopes
+         // (e.g. signing/key requests) are JSON objects without a `text` field.
+         const first = trimmed.charCodeAt(0);
+         if (first === 0x7b || first === 0x5b) { // '{' or '['
+           let obj;
+           try {
+             obj = JSON.parse(trimmed);
+           } catch (err) {
+             obj = null;
+           }
+           if (obj && typeof obj === 'object') {
+             if (typeof obj.thid === 'string') currentThid = obj.thid;
+             if (typeof obj.text === 'string' && obj.text.trim()) {
+               renderRemoteMessage(obj.text.trim());
+             } else {
+               console.log('AC2 envelope received (not chat):', obj);
+             }
+             return true;
+           }
+         }
+         // Bare-string chat (legacy `liquid` peer or plain-text AC2 message).
+         renderRemoteMessage(trimmed);
+         return true;
+       }
+
+       /**
+        * Route a negotiated data channel by label
+        *
+        * An AC2 wallet negotiates dedicated channels (`ac2-v1`, `ac2-stream`,
+        * `ac2-heartbeat`) rather than the single legacy `liquid` channel. We
+        * dispatch each to the right handler so heartbeats are counted on
+        * `ac2-heartbeat` (ping/pong) and agent status is read from `ac2-stream`.
+        *
+        * @param channel - The RTCDataChannel to route
+        */
+       function routeChannel(channel) {
+         console.log('Data channel negotiated:', channel.label);
+         switch (channel.label) {
+           case 'ac2-heartbeat':
+             isAc2 = true;
+             setupHeartbeatChannel(channel);
+             setConnectionStatus('Connected (AC2 wallet)', true);
+             break;
+           case 'ac2-stream':
+             isAc2 = true;
+             setupStreamChannel(channel);
+             setConnectionStatus('Connected (AC2 wallet)', true);
+             break;
+           case 'ac2-v1':
+             isAc2 = true;
+             setConnectionStatus('Connected (AC2 wallet)', true);
+             handleDataChannel(channel);
+             break;
+           default:
+             handleDataChannel(channel);
+         }
+       }
+
+       /**
+        * Wire up the dedicated `ac2-heartbeat` channel
+        *
+        * The wallet pings on an interval; we count every inbound frame as
+        * liveness and reply `pong` to its `ping` so its watchdog sees us alive.
+        * We also ping periodically so the indicator keeps pulsing when the wallet
+        * is quiet.
+        *
+        * @param channel - The `ac2-heartbeat` RTCDataChannel
+        */
+       function setupHeartbeatChannel(channel) {
+         heartbeatChannel = channel;
+         channel.onmessage = (e) => {
+           noteHeartbeat();
+           const data = typeof e.data === 'string' ? e.data : '';
+           console.log(`Heartbeat received${data ? ` (${data})` : ''}`);
+           if (data === 'ping') {
+             try {
+               if (channel.readyState === 'open') channel.send('pong');
+             } catch (err) {
+               /* noop */
+             }
+           }
+         };
+         const startPinging = () => {
+           if (heartbeatInterval) clearInterval(heartbeatInterval);
+           heartbeatInterval = setInterval(() => {
+             if (channel.readyState === 'open') {
+               try {
+                 channel.send('ping');
+               } catch (err) {
+                 /* noop */
+               }
+             }
+           }, 15000);
+         };
+         if (channel.readyState === 'open') startPinging();
+         else channel.onopen = startPinging;
+       }
+
+       /**
+        * Wire up the `ac2-stream` channel
+        *
+        * The agent emits STX-prefixed (0x02) JSON control frames describing its
+        * activity AND carrying its reply text (`preview`/`finalize`), and the
+        * wallet sends chat here as a plain `{ thid, text }` JSON envelope. All of
+        * it is decoded by `handleAc2Frame` so the debug app both updates the
+        * agent status pill and renders the actual messages the wallet/agent send.
+        *
+        * @param channel - The `ac2-stream` RTCDataChannel
+        */
+       function setupStreamChannel(channel) {
+         streamChannel = channel;
+         channel.onmessage = (e) => {
+           const raw = typeof e.data === 'string' ? e.data : '';
+           handleAc2Frame(raw);
+         };
+       }
+
+       /**
+        * Handle the messaging data channel (legacy `liquid` or AC2 `ac2-v1`)
         * @param dataChannel
         */
        function handleDataChannel(dataChannel) {
@@ -539,21 +1014,29 @@
          messagesContainer.classList.remove('hidden')
          callSession.classList.add('hidden')
 
+         if (!isAc2) {
+           setConnectionStatus('Connected', false);
+         }
+         updateHeartbeatStatus();
+
          if (connectedAddress) {
            loadMessages(connectedAddress);
          }
 
-         const messages = document.querySelector('.messages')
-
          lastUserActivity = Date.now();
 
-         heartbeatInterval = setInterval(() => {
-           if (globalThis.dc && globalThis.dc.readyState === 'open') {
-             console.log("Sending heartbeat message");
-             globalThis.dc.send('');
-             pulseIndicator();
-           }
-         }, 20000);
+         // Legacy peers keep liveness on the message channel via empty frames.
+         // AC2 wallets use the dedicated `ac2-heartbeat` channel instead, so we
+         // must NOT send empty keepalives here or they would surface as noise.
+         if (!isAc2) {
+           heartbeatInterval = setInterval(() => {
+             if (globalThis.dc && globalThis.dc.readyState === 'open') {
+               console.log("Sending heartbeat message");
+               globalThis.dc.send('');
+               pulseIndicator();
+             }
+           }, 20000);
+         }
 
          inactivityInterval = setInterval(() => {
            const now = Date.now();
@@ -563,25 +1046,28 @@
            }
          }, 5000);
 
-         dc.onmessage = (e) => {
+         dataChannel.onmessage = (e) => {
            lastUserActivity = Date.now();
-           pulseIndicator();
            if (!e.data) {
+             // Legacy empty-frame heartbeat.
+             noteHeartbeat();
              console.log("Heartbeat received");
              return;
            }
-           messages.innerHTML += `<div class="message-bubble remote-message">${e.data}</div>`
-           messages.scrollTop = messages.scrollHeight;
-           if (connectedAddress) {
-             saveMessage(connectedAddress, { text: e.data, sender: 'peer' });
-           }
+           const raw = typeof e.data === 'string' ? e.data : '';
+           // Route AC2 control frames / chat envelopes through the shared handler
+           // so `ac2-v1` renders messages the same way as `ac2-stream` (the
+           // wallet may fall back to `ac2-v1` when no stream channel exists).
+           if (handleAc2Frame(raw)) return;
+           // Anything else (e.g. non-string data): render as-is.
+           renderRemoteMessage(String(e.data));
          }
 
-         dc.onclose = () => {
+         dataChannel.onclose = () => {
            resetConnection('data channel closed by peer');
          };
 
-         dc.onerror = (error) => {
+         dataChannel.onerror = (error) => {
            console.error("Data channel error:", error);
            resetConnection('data channel error');
          };
@@ -590,9 +1076,13 @@
         * Create a peer connection, wait for an offer and send an answer to the remote client
         */
        async function handleOfferClient() {
-         // Peer to the remote client and await their offer
+         // Peer to the remote client and await their offer. Negotiated channels
+         // are dispatched by the `data-channel` listener (`routeChannel`), so we
+         // only need to surface errors here.
          console.log('requestId', requestId);
-         client.peer(requestId, 'offer', RTC_CONFIGURATION).then(handleDataChannel)
+         client.peer(requestId, 'offer', RTC_CONFIGURATION).catch((err) => {
+           console.error('Peer connection error:', err);
+         })
 
          // Once the link message is received by the remote wallet, hide the offer
          client.once('link-message', (data) => {
@@ -643,8 +1133,11 @@
 
          document.querySelector('.answer')?.classList.add('hidden')
 
-         // Create the Peer Connection and await the remote client's answer
-         client.peer(altRequestId, 'answer', RTC_CONFIGURATION).then(handleDataChannel)
+         // Create the Peer Connection and await the remote client's answer.
+         // Negotiated channels are dispatched by `routeChannel`.
+         client.peer(altRequestId, 'answer', RTC_CONFIGURATION).catch((err) => {
+           console.error('Peer connection error:', err);
+         })
        }
 
        // UI Functions
@@ -653,7 +1146,83 @@
          document.querySelector('.answer')?.classList.toggle('hidden')
        }
        function handleAlternativeRequestId() {
-         altRequestId = document.querySelector('input')?.value
+         altRequestId = document.querySelector('#alt-request')?.value
+       }
+
+       /**
+        * Update the local (offer) requestId from its input, persist it, and keep
+        * the remote (alt) id in sync when it still mirrors the local id. Lets us
+        * reuse a known requestId across reloads to test reconnect/reuse.
+        */
+       function handleLocalRequestId() {
+         const input = document.querySelector('#local-request');
+         const value = (input?.value || '').trim();
+         if (!value) return;
+         const mirrored = altRequestId === requestId;
+         requestId = value;
+         localStorage.setItem(REQUEST_ID_STORAGE_KEY, requestId);
+         if (mirrored) {
+           altRequestId = requestId;
+           const alt = document.querySelector('#alt-request');
+           if (alt) alt.value = altRequestId;
+         }
+       }
+
+       /**
+        * Forget the current requestId, mirroring the open-claw plugin's `ac2
+        * forget`: drop the persisted pairing id and mint a fresh UUID so the next
+        * pairing starts clean. Resets the visible ids and clears presence.
+        */
+       function forgetRequestId() {
+         localStorage.removeItem(REQUEST_ID_STORAGE_KEY);
+         requestId = SignalClient.generateRequestId();
+         localStorage.setItem(REQUEST_ID_STORAGE_KEY, requestId);
+         altRequestId = requestId;
+         const local = document.querySelector('#local-request');
+         if (local) local.value = requestId;
+         const alt = document.querySelector('#alt-request');
+         if (alt) alt.value = altRequestId;
+         renderPresence(document.querySelector('#offer-presence'), null);
+         renderPresence(document.querySelector('#answer-presence'), null);
+         console.log('Forgot requestId; new local id:', requestId);
+       }
+
+       /**
+        * Send the stored conversation history to the wallet as an `ac2-stream`
+        * `history` control frame, aligning with the open-claw reference plugin's
+        * `replayConversationHistory`. Local messages map to `user`, remote to
+        * `assistant`; sent over the stream channel when present, else `ac2-v1`.
+        */
+       function sendHistory() {
+         if (!connectedAddress) {
+           console.warn('No connected peer; cannot send history.');
+           return;
+         }
+         const stored = JSON.parse(localStorage.getItem(`messages_${connectedAddress}`) || '[]');
+         const messages = stored
+           .filter((m) => m && typeof m.text === 'string' && m.text.trim())
+           .map((m) => ({
+             role: m.sender === 'me' ? 'user' : 'assistant',
+             text: m.text,
+           }));
+         if (messages.length === 0) {
+           console.warn('No stored history to send.');
+           return;
+         }
+         const frame = AC2_STREAM_CONTROL_PREFIX + JSON.stringify({
+           t: 'history',
+           thid: currentThid,
+           messages,
+         });
+         if (streamChannel && streamChannel.readyState === 'open') {
+           streamChannel.send(frame);
+         } else if (globalThis.dc && globalThis.dc.readyState === 'open') {
+           globalThis.dc.send(frame);
+         } else {
+           console.warn('No open channel to send history over.');
+           return;
+         }
+         console.log(`Sent history (${messages.length} message(s)) on thid ${currentThid}`);
        }
 
 
@@ -663,7 +1232,11 @@
        globalThis.sendMessage = sendMessage
        globalThis.clearHistory = clearHistory
        globalThis.handleAlternativeRequestId = handleAlternativeRequestId
+       globalThis.handleLocalRequestId = handleLocalRequestId
+       globalThis.forgetRequestId = forgetRequestId
+       globalThis.sendHistory = sendHistory
        globalThis.resetConnection = resetConnection
+       globalThis.checkPresence = checkPresence
  })
      </script>
 </body>


### PR DESCRIPTION
# ℹ Overview

- Scope negotiation messages to RequestID rooms
- Allow room presence, any peers in the room signal availability (ie chat app "available" and "unavailable" status)
- Automatically resolve links for authenticated users with the same requestId
- Backwards compatibility for existing flows without presence.

### 📝 Related Issues

- resolves https://algorandfoundation.atlassian.net/browse/AFE-1264

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Conventional Commits
- [x] `yarn test:cov` passes
